### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the [catalog of demos](https://material-components.github.io/material-co
 
 ## About
 
-[Material Components for Web (MDC Web)](https://github.com/material-components/material-components-web) help developers execute [Material Design](https://www.material.io).
+[Material Components for the web (MDC Web)](https://github.com/material-components/material-components-web) help developers execute [Material Design](https://www.material.io).
 Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional web projects.
 
 ## Adding a new component
@@ -60,7 +60,7 @@ export default FooPage;
 
 ```
 
-2. Add a new file to the `src` directory for the styling the demo page (e.g. `FooPage.scss`):
+2. Add a new file to the `src` directory for styling the demo page (e.g. `FooPage.scss`):
 
 ```js
 @import "@material/foo/dist/mdc.foo";


### PR DESCRIPTION
Found a couple of typos in the README when I read it.

"Material Components for the web" is the wording we use in the main repo, so we should presumably also use it here.