### PR TITLE
fix: Update typography to match 0.35.0

### DIFF
--- a/src/ButtonPage.js
+++ b/src/ButtonPage.js
@@ -67,7 +67,7 @@ class ButtonDemos extends Component {
   renderButtonVariant(title, variantClass) {
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>{title}</h3>
+        <h3 className='mdc-typography--subtitle2'>{title}</h3>
         <button className={`demo-button mdc-button ${variantClass}`} ref={this.initRipple}>
           Default
         </button>

--- a/src/ComponentPage.js
+++ b/src/ComponentPage.js
@@ -46,18 +46,18 @@ class ComponentPage extends Component {
   renderDemoWrapper() {
     return(
       <section className='demo-wrapper mdc-layout-grid__cell mdc-layout-grid__cell--span-10'>
-        <h1 className='mdc-typography--headline'>{this.props.title}</h1>
-        <p className='mdc-typography--body1'>{this.props.description}</p>
+        <h1 className='mdc-typography--headline5'>{this.props.title}</h1>
+        <p className='mdc-typography--body2'>{this.props.description}</p>
         <div className='hero'>
           {this.props.hero}
         </div>
-        <h2 className='demo-title mdc-typography--title'>Resources</h2>
+        <h2 className='demo-title mdc-typography--headline6'>Resources</h2>
         {this.renderResource('Material Design Guidelines', `${imagePath}/ic_material_design_24px.svg`,
           this.props.designLink)}
         {this.renderResource('Documentation', `${imagePath}/ic_drive_document_24px.svg`, this.props.docsLink)}
         {this.renderResource('Source Code', `${imagePath}/ic_code_24px.svg`, this.props.sourceLink)}
 
-        <h2 className='demo-title mdc-typography--title'>Demos</h2>
+        <h2 className='demo-title mdc-typography--headline6'>Demos</h2>
         {this.props.demos}
       </section>
     );


### PR DESCRIPTION
I missed updating the typography classes when I updated the typography version. 

`body1` from old typography maps to `body2` of new typography. 
`subheading` maps to `subtitle`
`headline` maps to `headline5`
`title` maps to `headline6`