### PR TITLE
fix(checkbox): Add to webpack configs

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -27,6 +27,7 @@ const env = getClientEnvironment(publicUrl);
 // List of all component names for generating the corresponding html pages.
 const components = [
   'button',
+  'checkbox',
   'fab',
   'text-field'
 ];

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -49,6 +49,7 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
 // List of all component names for generating the corresponding html pages.
 const components = [
   'button',
+  'checkbox',
   'fab',
   'text-field'
 ];


### PR DESCRIPTION
This fixes the checkbox page when built. It was missed in #46.