### PR TITLE
fix: Add missing font weights for "Roboto"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/static/media/mdc_web_48dp.png">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/409245/39607863-6cca89fa-4ef2-11e8-84c4-0374cf11ced5.png)

After:
![image](https://user-images.githubusercontent.com/409245/39607867-71abfe68-4ef2-11e8-84c1-5c6686ec2005.png)

