### PR TITLE
fix: Fix empty iframes in Firefox and IE

### DIFF
--- a/src/DrawerCatalog.js
+++ b/src/DrawerCatalog.js
@@ -78,6 +78,7 @@ class DrawerDemos extends Component {
   getVariant(title, path) {
     const {match} = this.props;
     const drawerVariantLink = `#${match.url}/${path}`;
+    const src = `${window.location.protocol}//${window.location.host}${window.location.pathname}?bust${drawerVariantLink}`;
 
     return (
       <div className='drawer-demo'>
@@ -87,7 +88,7 @@ class DrawerDemos extends Component {
           </a>
         </div>
         <div>
-          <iframe className='drawer-iframe' title={title} src={`${window.location.href}/${path}`} />
+          <iframe className='drawer-iframe' title={title} src={src} />
         </div>
       </div>
     );

--- a/src/TopAppBarCatalog.js
+++ b/src/TopAppBarCatalog.js
@@ -73,6 +73,7 @@ class TopAppBarDemos extends Component {
   getVariant(title, path) {
     const {match} = this.props;
     const topAppBarVariantLink = `#${match.url}/${path}`;
+    const src = `${window.location.protocol}//${window.location.host}${window.location.pathname}?bust${topAppBarVariantLink}`;
 
     return (
       <div className='demo'>
@@ -82,7 +83,7 @@ class TopAppBarDemos extends Component {
           </a>
         </div>
         <div>
-          <iframe className='frame' title={title} src={`${window.location.href}/${path}`} />
+          <iframe className='frame' title={title} src={src} />
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #110.

Firefox and IE seemingly don't bother issuing network requests for iframes that reference the same URL as the parent. Adding a dummy GET parameter is enough to jog them into working.