### PR TITLE
Remove layout-grid from every component page

### DIFF
--- a/src/ComponentCatalogPanel.js
+++ b/src/ComponentCatalogPanel.js
@@ -20,7 +20,7 @@ class ComponentCatalogPanel extends Component {
   render() {
     const {designLink, description, demos, docsLink, hero, sourceLink, title} = this.props;
     return(
-      <section className='demo-wrapper'>
+      <section>
         <h1 className='mdc-typography--headline'>{title}</h1>
         <p className='mdc-typography--body1'>{description}</p>
         <div className='hero'>

--- a/src/ComponentCatalogPanel.js
+++ b/src/ComponentCatalogPanel.js
@@ -20,7 +20,7 @@ class ComponentCatalogPanel extends Component {
   render() {
     const {designLink, description, demos, docsLink, hero, sourceLink, title} = this.props;
     return(
-      <section className='demo-wrapper mdc-layout-grid__cell mdc-layout-grid__cell--span-10'>
+      <section className='demo-wrapper'>
         <h1 className='mdc-typography--headline'>{title}</h1>
         <p className='mdc-typography--body1'>{description}</p>
         <div className='hero'>

--- a/src/ComponentPage.js
+++ b/src/ComponentPage.js
@@ -103,7 +103,7 @@ class ComponentPage extends Component {
   }
 
   render() {
-    const classes = classnames('mdc-layout-grid', 'demo-content', {
+    const classes = classnames('demo-content', {
       'demo-content--animating-open': this.state.opening,
       'demo-content--animating-close': this.state.closing,
     });
@@ -113,9 +113,7 @@ class ComponentPage extends Component {
         <div className='mdc-top-app-bar--fixed-adjust demo-panel'>
           <ComponentSidebar {...this.props} handleOpen={this.handleOpen_} handleClose={this.handleClose_} />
           <div className={classes} ref={this.initDemoContent} onTransitionEnd={this.handleTransitionEnd_}>
-            <div className='mdc-layout-grid__inner'>
-              {this.renderComponentRoutes()}
-            </div>
+            {this.renderComponentRoutes()}
           </div>
         </div>
       </div>

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -19,7 +19,7 @@ body {
   @include mdc-image-list-aspect(1); // Images are square
   @include mdc-image-list-standard-columns(4, $component-list-gutter-size);
 
-  max-width: 1000px;
+  max-width: 900px;
   padding-top: 128px;
   padding-bottom: 100px;
 }

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -47,6 +47,6 @@
 .demo-content {
   width: 1000px;
   margin: 0 auto;
-  padding-top: 24px;
+  padding: 24px;
   padding-bottom: 100px;
 }

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -16,10 +16,6 @@
   font-weight: 600;
 }
 
-.demo-wrapper {
-  max-width: 1000px;
-}
-
 .demo-title {
   border-bottom: 1px solid rgba(0, 0, 0, .87);
 }

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -45,7 +45,7 @@
 }
 
 .demo-content {
-  width: 1000px;
+  width: 900px;
   margin: 0 auto;
   padding: 16px;
   padding-top: 40px;

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -47,6 +47,7 @@
 .demo-content {
   width: 1000px;
   margin: 0 auto;
-  padding: 24px;
+  padding: 16px;
+  padding-top: 40px;
   padding-bottom: 100px;
 }

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -1,4 +1,3 @@
-@import "@material/layout-grid/dist/mdc.layout-grid";
 @import "@material/list/dist/mdc.list";
 @import "@material/typography/mixins";
 @import "./variables";
@@ -50,5 +49,8 @@
 }
 
 .demo-content {
+  width: 1000px;
+  margin: 0 auto;
+  padding-top: 24px;
   padding-bottom: 100px;
 }

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -47,7 +47,5 @@
 .demo-content {
   width: 900px;
   margin: 0 auto;
-  padding: 16px;
-  padding-top: 40px;
-  padding-bottom: 100px;
+  padding: 40px 16px 100px;
 }

--- a/src/styles/ComponentView.scss
+++ b/src/styles/ComponentView.scss
@@ -16,10 +16,6 @@
   font-weight: 600;
 }
 
-.demo-wrapper {
-  max-width: 1000px;
-}
-
 .demo-title {
   border-bottom: 1px solid rgba(0, 0, 0, .87);
 }

--- a/src/styles/ImageListCatalog.scss
+++ b/src/styles/ImageListCatalog.scss
@@ -16,12 +16,12 @@
   @include mdc-image-list-aspect(1.5); // Images are 3:2
   @include mdc-image-list-standard-columns(5);
 
-  max-width: 1000px;
+  max-width: 900px;
 }
 
 .masonry-image-list {
   @include mdc-image-list-masonry-columns(5);
-  max-width: 1000px;
+  max-width: 900px;
 }
 
 @media (max-width: 599px) {


### PR DESCRIPTION
Remove mdc-layout-grid from every component page since we're using drawer for the sidebar.
Also make the demo-content width consistent for every component page.