### PR TITLE
fix(typography): Make headings consistent

### DIFF
--- a/src/ButtonCatalog.js
+++ b/src/ButtonCatalog.js
@@ -63,7 +63,7 @@ class ButtonDemos extends Component {
   renderButtonVariant(title, variantClass) {
     return (
       <div>
-        <h3>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <button className={`demo-button mdc-button ${variantClass}`} ref={this.initRipple}>
           Default
         </button>

--- a/src/CheckboxCatalog.js
+++ b/src/CheckboxCatalog.js
@@ -81,7 +81,7 @@ class CheckboxDemos extends Component {
   renderCheckboxVariant(title, inputRefCallback) {
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div className='mdc-checkbox demo-checkbox' ref={this.initCheckbox}>
           <input type='checkbox'
                  className='mdc-checkbox__native-control'

--- a/src/ChipsCatalog.js
+++ b/src/ChipsCatalog.js
@@ -106,7 +106,7 @@ class ChipsDemos extends Component {
     const initChipSet = chipSetEl => chipSetEl && this.chipSets.push(new MDCChipSet(chipSetEl));
     return (
       <div>
-        <h3>Choice Chips</h3>
+        <h3 className='mdc-typography--subtitle1'>Choice Chips</h3>
         <div className='mdc-chip-set mdc-chip-set--choice' ref={initChipSet}>
           {this.renderChip('Extra Small')}
           {this.renderChip('Small')}
@@ -115,7 +115,7 @@ class ChipsDemos extends Component {
           {this.renderChip('Extra Large')}
         </div>
 
-        <h3>Filter Chips</h3>
+        <h3 className='mdc-typography--subtitle1'>Filter Chips</h3>
         <h3 className='mdc-typography--body2'>No leading icon</h3>
         <div className='mdc-chip-set mdc-chip-set--filter' ref={initChipSet}>
           {this.renderFilterChip('Tops', 'mdc-chip--selected')}
@@ -140,7 +140,7 @@ class ChipsDemos extends Component {
         </div>
 
         <div className='catalog-variant'>
-          <h3>Action Chips</h3>
+          <h3 className='mdc-typography--subtitle1'>Action Chips</h3>
           <div className='mdc-chip-set' ref={initChipSet}>
             {this.renderChip('Add to calendar',
               '' /* classes */,

--- a/src/ComponentCatalogPanel.js
+++ b/src/ComponentCatalogPanel.js
@@ -21,17 +21,17 @@ class ComponentCatalogPanel extends Component {
     const {designLink, description, demos, docsLink, hero, sourceLink, title} = this.props;
     return(
       <section className='demo-wrapper mdc-layout-grid__cell mdc-layout-grid__cell--span-10'>
-        <h1 className='mdc-typography--headline'>{title}</h1>
+        <h1 className='mdc-typography--headline5'>{title}</h1>
         <p className='mdc-typography--body1'>{description}</p>
         <div className='hero'>
           {hero}
         </div>
-        <h2 className='demo-title mdc-typography--title'>Resources</h2>
+        <h2 className='demo-title mdc-typography--headline6'>Resources</h2>
         {this.renderResource('Material Design Guidelines', `${imagePath}/ic_material_design_24px.svg`, designLink)}
         {this.renderResource('Documentation', `${imagePath}/ic_drive_document_24px.svg`, docsLink)}
         {this.renderResource('Source Code', `${imagePath}/ic_code_24px.svg`, sourceLink)}
 
-        <h2 className='demo-title mdc-typography--title'>Demos</h2>
+        <h2 className='demo-title mdc-typography--headline6'>Demos</h2>
         {demos}
       </section>
     );

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -92,7 +92,7 @@ class DialogDemos extends Component {
   render() {
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>Scrollable Dialog</h3>
+        <h3 className='mdc-typography--subtitle1'>Scrollable Dialog</h3>
         <Dialog open={this.state.open} handleAccept={this.handleAccept_} handleCancel={this.handleCancel_}/>
         <button className='mdc-button' onClick={this.handleOpenClick_}>Open dialog</button>
         {this.renderMessage()}

--- a/src/DrawerCatalog.js
+++ b/src/DrawerCatalog.js
@@ -84,7 +84,7 @@ class DrawerDemos extends Component {
       <div className='drawer-demo'>
         <div>
           <a href={drawerVariantLink} target='_blank'>
-            <h3 className='mdc-typography--subtitle2'>{title}</h3>
+            <h3 className='mdc-typography--subtitle1'>{title}</h3>
           </a>
         </div>
         <div>

--- a/src/FabCatalog.js
+++ b/src/FabCatalog.js
@@ -31,10 +31,10 @@ class Fab extends Component {
 
 const FabDemos = () => (
   <div>
-    <h3 className='mdc-typography--subheading2'>Standard Floating Action Button</h3>
+    <h3 className='mdc-typography--subtitle1'>Standard Floating Action Button</h3>
     <Fab />
 
-    <h3 className='mdc-typography--subheading2'>Mini Floating Action Button</h3>
+    <h3 className='mdc-typography--subtitle1'>Mini Floating Action Button</h3>
     <Fab mini />
   </div>
 );

--- a/src/ImageListCatalog.js
+++ b/src/ImageListCatalog.js
@@ -57,10 +57,10 @@ function ImageListDemos() {
 
   return (
     <div>
-      <h3 className='mdc-typography--subheading2'>Standard Image List with Text Protection</h3>
+      <h3 className='mdc-typography--subtitle1'>Standard Image List with Text Protection</h3>
       <ImageList className='standard-image-list mdc-image-list--with-text-protection' items={standardImageListItems}
         includeAspectContainer />
-      <h3 className='mdc-typography--subheading2'>Masonry Image List</h3>
+      <h3 className='mdc-typography--subtitle1'>Masonry Image List</h3>
       <ImageList className='mdc-image-list--masonry masonry-image-list' items={masonryImageListItems} />
     </div>
   );

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -32,7 +32,7 @@ const LayoutGridHero = () => {
 const LayoutGridDemos = () => {
   return (
     <div>
-      <h3 className='mdc-typography--subheading2'>Columns</h3>
+      <h3 className='mdc-typography--subtitle1'>Columns</h3>
       <LayoutGrid className='demo-grid'>
         <LayoutGridInner>
           <LayoutGridCell className='demo-cell' cols='6'></LayoutGridCell>
@@ -45,7 +45,7 @@ const LayoutGridDemos = () => {
         </LayoutGridInner>
       </LayoutGrid>
 
-      <h3 className='mdc-typography--subheading2'>Grid Left Alignment</h3>
+      <h3 className='mdc-typography--subtitle1'>Grid Left Alignment</h3>
       <p>This requires a max-width on the top-level grid element.</p>
       <LayoutGrid className='demo-grid demo-grid--alignment' align='left'>
         <LayoutGridInner>
@@ -55,7 +55,7 @@ const LayoutGridDemos = () => {
         </LayoutGridInner>
       </LayoutGrid>
 
-      <h3 className='mdc-typography--subheading2'>Right Alignment</h3>
+      <h3 className='mdc-typography--subtitle1'>Right Alignment</h3>
       <p>This requires a max-width on the top-level grid element.</p>
       <LayoutGrid className='demo-grid demo-grid--alignment' align='right'>
         <LayoutGridInner>
@@ -65,7 +65,7 @@ const LayoutGridDemos = () => {
         </LayoutGridInner>
       </LayoutGrid>
 
-      <h3 className='mdc-typography--subheading2'>Cell Alignment</h3>
+      <h3 className='mdc-typography--subtitle1'>Cell Alignment</h3>
       <p>Cell alignment requires a cell height smaller than the inner height of the grid.</p>
       <LayoutGrid className='demo-grid demo-grid--cell-alignment'>
         <LayoutGridInner className='demo-inner'>

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -46,7 +46,7 @@ const LayoutGridDemos = () => {
       </LayoutGrid>
 
       <h3 className='mdc-typography--subtitle1'>Grid Left Alignment</h3>
-      <p>This requires a max-width on the top-level grid element.</p>
+      <p className='mdc-typography--body2'>This requires a max-width on the top-level grid element.</p>
       <LayoutGrid className='demo-grid demo-grid--alignment' align='left'>
         <LayoutGridInner>
           <LayoutGridCell className='demo-cell'></LayoutGridCell>
@@ -56,7 +56,7 @@ const LayoutGridDemos = () => {
       </LayoutGrid>
 
       <h3 className='mdc-typography--subtitle1'>Right Alignment</h3>
-      <p>This requires a max-width on the top-level grid element.</p>
+      <p className='mdc-typography--body2'>This requires a max-width on the top-level grid element.</p>
       <LayoutGrid className='demo-grid demo-grid--alignment' align='right'>
         <LayoutGridInner>
           <LayoutGridCell className='demo-cell'></LayoutGridCell>
@@ -66,7 +66,7 @@ const LayoutGridDemos = () => {
       </LayoutGrid>
 
       <h3 className='mdc-typography--subtitle1'>Cell Alignment</h3>
-      <p>Cell alignment requires a cell height smaller than the inner height of the grid.</p>
+      <p className='mdc-typography--body2'>Cell alignment requires a cell height smaller than the inner height of the grid.</p>
       <LayoutGrid className='demo-grid demo-grid--cell-alignment'>
         <LayoutGridInner className='demo-inner'>
           <LayoutGridCell className='demo-cell demo-cell--alignment' align='top'></LayoutGridCell>

--- a/src/LinearProgressIndicatorCatalog.js
+++ b/src/LinearProgressIndicatorCatalog.js
@@ -73,7 +73,7 @@ class LinearProgressDemos extends Component {
     const initFunction = buffer ? this.initBufferIndicator : this.initIndicator;
     return (
       <div className='demo-linear-progress-indicator'>
-        <h3>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div role='progressbar'
           className={`mdc-linear-progress ${variantClass}`}
           ref={initFunction}>

--- a/src/ListCatalog.js
+++ b/src/ListCatalog.js
@@ -95,7 +95,7 @@ class List extends Component {
 
 const ListVariant = (props) => (
   <div>
-    <h3 className='mdc-typography--subheading2'>{props.title}</h3>
+    <h3 className='mdc-typography--subtitle1'>{props.title}</h3>
     <List {...props} />
   </div>
 );

--- a/src/MenuCatalog.js
+++ b/src/MenuCatalog.js
@@ -51,7 +51,7 @@ class MenuDemos extends Component {
   render() {
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>Anchored Menu</h3>
+        <h3 className='mdc-typography--subtitle1'>Anchored Menu</h3>
         <button className='mdc-button' onClick={this.handleOpenClick_}>Open menu</button>
         <div className='mdc-menu-anchor'>
           <Menu open={this.state.open} focusIndex={this.state.focusIndex} handleSelected={this.handleSelected_} handleCancel={this.handleCancel_}>

--- a/src/RadioButtonCatalog.js
+++ b/src/RadioButtonCatalog.js
@@ -32,7 +32,7 @@ const RadioButtonHero = () => {
 const RadioButtonDemos = () => {
   return (
     <div>
-      <h3 className='mdc-typography--subtitle2'>Radio Buttons</h3>
+      <h3 className='mdc-typography--subtitle1'>Radio Buttons</h3>
       <RadioFormField className='demo-radio-form-field' name='demo-radio-set' label='Radio 1' defaultChecked />
       <RadioFormField className='demo-radio-form-field' name='demo-radio-set' label='Radio 2' />
     </div>

--- a/src/RippleCatalog.js
+++ b/src/RippleCatalog.js
@@ -58,7 +58,7 @@ class RippleDemos extends Component {
         <div>
           <div className='ripple-demos'>
             <div className='ripple-demo-col'>
-              <h3>{title}</h3>
+              <h3 className='mdc-typography--subtitle1'>{title}</h3>
               <div tabIndex='0' className={variant} ref={this.initRipple}>
                 {text}
               </div>

--- a/src/SelectCatalog.js
+++ b/src/SelectCatalog.js
@@ -69,7 +69,7 @@ class SelectDemos extends Component {
   renderSelectVariant(title, variantClass) {
     return (
       <div>
-        <h3>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div className={`mdc-select demo-select ${variantClass}`} ref={this.initSelect}>
           <select className='mdc-select__native-control' defaultValue=''>
             <option value='' disabled></option>

--- a/src/ShapeCatalog.js
+++ b/src/ShapeCatalog.js
@@ -58,7 +58,7 @@ class ShapeDemos extends Component {
   render() {
     return (
       <div>
-        <h3>Contained Button</h3>
+        <h3 className='mdc-typography--subtitle1'>Contained Button</h3>
         <div className='contained-button-shape-container mdc-shape-container'>
           <button className='mdc-button mdc-button--unelevated' ref={this.initRipple}>Skip</button>
           {this.renderCorner('top-left')}
@@ -72,7 +72,7 @@ class ShapeDemos extends Component {
           {this.renderCorner('bottom-right')}
         </div>
 
-        <h3>Outlined Button</h3>
+        <h3 className='mdc-typography--subtitle1'>Outlined Button</h3>
         <div className='outlined-button-shape-container mdc-shape-container'>
           <button className='mdc-button mdc-button--outlined' ref={this.initRipple}>Skip</button>
           {this.renderCorner('top-left')}
@@ -86,7 +86,7 @@ class ShapeDemos extends Component {
           {this.renderCorner('bottom-right')}
         </div>
 
-        <h3>Card</h3>
+        <h3 className='mdc-typography--subtitle1'>Card</h3>
         <div className='card-shape-container mdc-shape-container'>
           <div className='mdc-card mdc-card--outlined'>
             <div className='mdc-card__primary-action' ref={this.initRipple}>

--- a/src/SliderCatalog.js
+++ b/src/SliderCatalog.js
@@ -61,7 +61,7 @@ class SliderDemos extends Component {
   renderSliderVariant(title, variantClass) {
     return (
       <div className='demo-slider'>
-        <h3>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div className={`mdc-slider ${variantClass}`} tabIndex='0' role='slider'
           aria-valuemin='0' aria-valuemax='50' aria-valuenow='25'
           aria-label='Select Value'

--- a/src/SnackbarCatalog.js
+++ b/src/SnackbarCatalog.js
@@ -57,7 +57,7 @@ class SnackbarDemo extends Component {
   render() {
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>Snackbars</h3>
+        <h3 className='mdc-typography--subtitle1'>Snackbars</h3>
         <button className='mdc-button mdc-button--raised snackbar-demo-button' onClick={this.handleShowClick}>
           Show snackbar
         </button>

--- a/src/SwitchCatalog.js
+++ b/src/SwitchCatalog.js
@@ -50,7 +50,7 @@ class SwitchDemos extends Component {
   renderSwitchVariant(title, variant) {
     return (
         <div>
-          <h3 className='mdc-typography--subtitle2'>{title}</h3>
+          <h3 className='mdc-typography--subtitle1'>{title}</h3>
           <div className='switch-demo'>
           <div className='mdc-switch'>
             <input type='checkbox' id={`${title}-switch`} className='mdc-switch__native-control' role='switch'

--- a/src/TabsCatalog.js
+++ b/src/TabsCatalog.js
@@ -32,7 +32,7 @@ const TabsHero = () => {
 const TabsDemos = () => {
   return (
     <div>
-      <h3 className='mdc-typography--subheading2'>Scrolling Tabs</h3>
+      <h3 className='mdc-typography--subtitle1'>Scrolling Tabs</h3>
       <TabScroller>
         <Tab active name='Passionfruit' />
         <Tab name='Orange' />

--- a/src/TextFieldCatalog.js
+++ b/src/TextFieldCatalog.js
@@ -114,7 +114,7 @@ class TextFieldDemos extends Component {
     const variantId = args.reduce((allArgs, arg) => `${allArgs}-${arg}`, '');
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div className='text-field-row'>
           <TextField {...variants} textFieldId={`text-field-${variantId}`} />
           <TextField {...variants} dense textFieldId={`text-field-${variantId}-dense`} />
@@ -130,7 +130,7 @@ class TextFieldDemos extends Component {
     const variantId = args.reduce((allArgs, arg) => `${allArgs}-${arg}`, 'fullwidth');
     return (
       <div>
-        <h3 className='mdc-typography--subheading2'>{title}</h3>
+        <h3 className='mdc-typography--subtitle1'>{title}</h3>
         <div className='text-field-row text-field-row-fullwidth'>
           <FullWidthTextField {...variants} textFieldId={`text-field-${variantId}`} />
           <FullWidthTextField {...variants} dense textFieldId={`text-field-${variantId}-dense`} />

--- a/src/TopAppBarCatalog.js
+++ b/src/TopAppBarCatalog.js
@@ -79,7 +79,7 @@ class TopAppBarDemos extends Component {
       <div className='demo'>
         <div>
           <a href={topAppBarVariantLink} target='_blank'>
-            <h3 className='mdc-typography--subtitle2'>{title}</h3>
+            <h3 className='mdc-typography--subtitle1'>{title}</h3>
           </a>
         </div>
         <div>


### PR DESCRIPTION
Make all demo headings `subtitle1` to align with design. 
Remove levels that no longer exist in MDC Typography, like `subheading2`, `headline`, `title`.