### PR TITLE
Fix overflowing demo content

### DIFF
--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -45,7 +45,9 @@
 }
 
 .demo-content {
+  box-sizing: border-box;
   width: 900px;
+  max-width: 100%;
   margin: 0 auto;
   padding: 40px 16px 100px;
 }


### PR DESCRIPTION
Fixes the demo-content overflowing the window.

Fix the demo content from looking like this on small devices...
![image](https://user-images.githubusercontent.com/5939574/43555605-0d1e4226-95b0-11e8-819d-372aecf17767.png)

...to looking like this on small devices...

![image](https://user-images.githubusercontent.com/5939574/43555620-2f67ec6a-95b0-11e8-97fa-e8347b5f814a.png)
