### PR TITLE
fix(tab-bar): Rename Tabs page to Tab Bar to disambiguate

### DIFF
--- a/src/ComponentImageList.js
+++ b/src/ComponentImageList.js
@@ -63,7 +63,7 @@ class ComponentImageList extends Component {
           {this.renderListItem('Slider', sliderImg, 'slider')}
           {this.renderListItem('Snackbar', snackbarImg, 'snackbar')}
           {this.renderListItem('Switch', switchImg, 'switch')}
-          {this.renderListItem('Tabs', tabsImg, 'tabs')}
+          {this.renderListItem('Tab Bar', tabsImg, 'tabs')}
           {this.renderListItem('Text Field', inputImg, 'text-field')}
           {this.renderListItem('Theme', themeImg, 'theme')}
           {this.renderListItem('Top App Bar', topAppBarImg, 'top-app-bar')}

--- a/src/ComponentSidebar.js
+++ b/src/ComponentSidebar.js
@@ -183,7 +183,7 @@ class ComponentSidebar extends Component {
       content: 'Switch',
       url: '/switch',
     }, {
-      content: 'Tabs',
+      content: 'Tab Bar',
       url: '/tabs',
     }, {
       content: 'Text Field',

--- a/src/TabsCatalog.js
+++ b/src/TabsCatalog.js
@@ -9,7 +9,7 @@ const TabsCatalog = () => {
   return (
     <ComponentCatalogPanel
       hero={<TabsHero />}
-      title='Tabs'
+      title='Tab Bar'
       description='Tabs make it easy to explore and switch between different views.'
       designLink='https://material.io/go/design-tabs'
       docsLink='https://material.io/components/web/catalog/tabs/'


### PR DESCRIPTION
This renames "Tabs" to "Tab Bar" in the index, sidebar, and tabs catalog page, in an effort to clarify that it pertains to the new MDC Tab Bar component, not the deprecated MDC Tabs component. This was previously causing some confusion.

This does not rename the route, in an effort to preserve links that already worked.