### PR TITLE
fix(drawer): Fixes scrollbar gets hidden on drawer open issue.

### DIFF
--- a/src/ComponentPage.js
+++ b/src/ComponentPage.js
@@ -35,7 +35,7 @@ class ComponentPage extends Component {
     return (
       <div className='demo-panel'>
         <ComponentSidebar {...this.props} />
-        <div className='demo-content mdc-top-app-bar--fixed-adjust' ref={this.initDemoContent}>
+        <div className='demo-content mdc-drawer-app-content mdc-top-app-bar--fixed-adjust' ref={this.initDemoContent}>
           {this.renderComponentRoutes()}
         </div>
       </div>

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -59,24 +59,16 @@
   max-width: 100%;
   padding: 40px 16px 100px;
   transition: 200ms transform cubic-bezier(.4, 0, .2, 1) 50ms;
-  display: flex;
-  justify-content: center;
   width: 100%;
   overflow: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 .demo-content-transition {
-  height: 100%;
   width: 900px;
-}
-
-.mdc-drawer--open + .demo-content {
-  transform: translateX($mdc-drawer-width / 2);
-}
-
-.mdc-drawer--closing + .demo-content {
-  transition: 125ms transform cubic-bezier(.4, 0, .2, 1);
-  transform: none;
 }
 
 .loadComponent-enter {

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -1,5 +1,4 @@
 @import "@material/list/mdc-list";
-@import "@material/drawer/variables";
 @import "@material/drawer/mdc-drawer";
 @import "@material/typography/mixins";
 @import "./variables";


### PR DESCRIPTION
Removed `translateX` animation on demo content and added `mdc-drawer-app-content` class to set appropriate margin.