### PR TITLE
fix: Avoid pile-up of drawer instantiations

### DIFF
--- a/src/ComponentSidebar.js
+++ b/src/ComponentSidebar.js
@@ -10,7 +10,7 @@ const MODAL_DRAWER_CLASS = 'mdc-drawer--modal';
 
 class ComponentSidebar extends Component {
   state = {
-    variant: DISMISSIBLE_DRAWER_CLASS,
+    variant: document.body.offsetWidth > SCREEN_WIDTH_BREAKPOINT ? DISMISSIBLE_DRAWER_CLASS : MODAL_DRAWER_CLASS,
   };
 
   drawer = null;
@@ -22,14 +22,13 @@ class ComponentSidebar extends Component {
   handleDrawerClose_ = () => this.handleDrawerClose();
 
   initDrawer = ele => {
-    if(!ele) return;
+    if (!ele) {
+      return;
+    }
     this.drawerEl = ele;
 
-    if(document.body.offsetWidth > SCREEN_WIDTH_BREAKPOINT) {
-
-      this.setState({variant: DISMISSIBLE_DRAWER_CLASS});
-    } else {
-      this.setState({variant: MODAL_DRAWER_CLASS});
+    if (this.drawer) {
+      this.drawer.destroy();
     }
     this.drawer = new MDCDrawer(this.drawerEl);
   };
@@ -223,28 +222,22 @@ class ComponentSidebar extends Component {
         this.drawer.open = false;
       }
       setTimeout(() => {
-        this.drawer.destroy();
         this.setState({variant: MODAL_DRAWER_CLASS});
-        this.drawer = new MDCDrawer(this.drawerEl);
-      }, 225)
-
+      }, 225);
     } else if(document.body.offsetWidth > SCREEN_WIDTH_BREAKPOINT &&
         this.state.variant === MODAL_DRAWER_CLASS) {
       if (this.drawer.open) {
         this.drawer.open = false;
       }
       setTimeout(() => {
-        this.drawer.destroy();
         this.setState({variant: DISMISSIBLE_DRAWER_CLASS});
-        this.drawer = new MDCDrawer(this.drawerEl);
-      }, 225)
+      }, 225);
     }
   }
 
   debounceResizeMethod_ = () => {
     clearTimeout(this.debounceTimeout);
-    this.debounceTimeout = setTimeout(() =>
-        this.handleResize_(), 50)
+    this.debounceTimeout = setTimeout(() => this.handleResize_(), 50);
   };
 
   handleListItemKeyDown_ = (history, path, e) => {


### PR DESCRIPTION
Fixes #194.

The issue was somewhat confusing to diagnose due to the fact that we're destroying/reinstantiating the drawer directly in the resize handler (as well as instantiating in initDrawer), and while we are debouncing resize calls, we aren't doing the same for the 225ms timeouts set up within the resize handler. It's possible for multiple 225ms timeouts to be scheduled because the condition for setting them up is still true the next time the debounced resize handler is called (~50ms) but before the first scheduled drawer destruction/instantiation is executed (~175ms left).

The main issue, however, was that the Drawer instantiation inside the resize handler is redundant - updating the state will cause render to be called, which will in turn call initDrawer, which should be the only place where instantiation (and destruction) needs to happen. Then the lack of debouncing of the 225ms timeouts doesn't matter, because setting the state to the same value again results in no render call.

I also removed some `setState` calls from `initDrawer` that are also mostly redundant, since we're already updating state in the resize handler; the only other time state needs to be set is initially, so I updated the initial state assignment.