### PR TITLE
feat(dialog): Add spec examples to catalog page

### DIFF
--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -37,6 +37,7 @@ class DialogHero extends Component {
           role='alertdialog'
           aria-labelledby='my-mdc-dialog-label'
           aria-describedby='my-mdc-dialog-description'
+          ref={this.initDialog}
           >
           <div className='mdc-dialog__container'>
             <div className='mdc-dialog__surface'>

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -33,17 +33,14 @@ class DialogHero extends Component {
     return (
       <div>
         <div id='my-mdc-dialog'
-             className='mdc-dialog mdc-dialog--open hero-demo'
-             role='alertdialog'
-             aria-labelledby='my-mdc-dialog-label'
-             aria-describedby='my-mdc-dialog-description'
-             ref={this.initDialog}
-        >
+          className='mdc-dialog mdc-dialog--open hero-demo'
+          role='alertdialog'
+          aria-labelledby='my-mdc-dialog-label'
+          aria-describedby='my-mdc-dialog-description'
+          >
           <div className='mdc-dialog__container'>
             <div className='mdc-dialog__surface'>
-              <h2 id='my-mdc-dialog-label' className='mdc-dialog__title'>
-                Get this party started?
-              </h2>
+              <h2 id='my-mdc-dialog-label' className='mdc-dialog__title'>Get this party started?</h2>
               <section id='my-mdc-dialog-description' className='mdc-dialog__content'>
                 Turn up the jams and have a good time.
               </section>

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {MDCDialog} from '@material/dialog/dist/mdc.dialog';
+import {MDCList} from '@material/list/dist/mdc.list';
 
 import './styles/DialogCatalog.scss';
 
@@ -159,17 +160,16 @@ class AlertDialog extends Component {
   render() {
     return (
       <div>
-        <div id='mdc-dialog-with-list'
+        <div id='alert-dialog'
           className='mdc-dialog'
           role='alertdialog'
           aria-modal='true'
-          aria-labelledby='mdc-dialog-with-list-label'
-          aria-describedby='mdc-dialog-with-list-description'
+          aria-describedby='alert-dialog-description'
           ref={this.initDialog}>
           <div className='mdc-dialog__scrim'></div>
           <div className='mdc-dialog__container'>
             <div className='mdc-dialog__surface'>
-              <section id='mdc-dialog-with-list-description' className='mdc-dialog__content'>
+              <section id='alert-dialog-description' className='mdc-dialog__content'>
                 <p>Discard draft?</p>
               </section>
               <footer className='mdc-dialog__actions'>
@@ -191,6 +191,12 @@ class SimpleDialog extends Component {
     this.dialogEl = dialogEl;
     this.dialog = new MDCDialog(dialogEl);
   };
+
+  initList = (listEl) => {
+    if (!listEl) return;
+    this.listEl = listEl;
+    this.list = new MDCList(listEl);
+  }
 
   componentDidUpdate(prevProps) {
     if (!prevProps.open && this.props.open) {
@@ -231,7 +237,7 @@ class SimpleDialog extends Component {
                   // Inline `style='list-style-type: none'` needed to prevent rendering bug in Edge and IE 11.
                   // See https://stackoverflow.com/a/23717689/467582
                 }
-                <ul className='mdc-list mdc-list--avatar-list' style={{listStyleType: 'none'}}>
+                <ul ref={this.initList} className='mdc-list mdc-list--avatar-list' style={{listStyleType: 'none'}}>
                   <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='user1@example.com'>
                     <i className='material-icons mdc-list-item__graphic'>person</i>
                     <span className='test-list-item__label'>user1@example.com</span>
@@ -262,6 +268,12 @@ class ConfirmationDialog extends Component {
     this.dialog = new MDCDialog(dialogEl);
   };
 
+  initList = (listEl) => {
+    if (!listEl) return;
+    this.listEl = listEl;
+    this.list = new MDCList(listEl);
+  }
+
   componentDidUpdate(prevProps) {
     if (!prevProps.open && this.props.open) {
       // Handle transitioning from closed to open; dialog will handle closing itself
@@ -285,23 +297,23 @@ class ConfirmationDialog extends Component {
   render() {
     return (
       <div>
-        <div id='simple-dialog'
+        <div id='confirmation-dialog'
           className='mdc-dialog'
           role='alertdialog'
           aria-modal='true'
-          aria-labelledby='simple-dialog-label'
-          aria-describedby='simple-dialog-description'
+          aria-labelledby='confirmation-dialog-label'
+          aria-describedby='confirmation-dialog-description'
           ref={this.initDialog}>
           <div className='mdc-dialog__scrim'></div>
           <div className='mdc-dialog__container'>
             <div className='mdc-dialog__surface'>
-              <h2 id='simple-dialog-label' className='mdc-dialog__title'>Phone ringtone</h2>
-              <section id='simple-dialog-description' className='mdc-dialog__content'>
+              <h2 id='confirmation-dialog-label' className='mdc-dialog__title'>Phone ringtone</h2>
+              <section id='confirmation-dialog-description' className='mdc-dialog__content'>
                 {
                   // Inline `style='list-style-type: none'` needed to prevent rendering bug in Edge and IE 11.
                   // See https://stackoverflow.com/a/23717689/467582
                 }
-                <ul className='mdc-list' style={{listStyleType: 'none'}}>
+                <ul ref={this.initList} className='mdc-list' style={{listStyleType: 'none'}}>
                   <li className='mdc-list-item' tabIndex='0'>
                     <span className='mdc-list-item__graphic'>
                       <div className='mdc-radio'>

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -297,7 +297,7 @@ class ConfirmationDialog extends Component {
           <div className='mdc-dialog__scrim'></div>
           <div className='mdc-dialog__container'>
             <div className='mdc-dialog__surface'>
-              <h2 id='simple-dialog-label' className='mdc-dialog__title'>Select an account</h2>
+              <h2 id='simple-dialog-label' className='mdc-dialog__title'>Phone ringtone</h2>
               <section id='simple-dialog-description' className='mdc-dialog__content'>
                 {
                   // Inline `style='list-style-type: none'` needed to prevent rendering bug in Edge and IE 11.
@@ -319,7 +319,7 @@ class ConfirmationDialog extends Component {
                         </div>
                       </div>
                     </span>
-                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-1'>Option 1</label>
+                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-1'>Never Gonna Give You Up</label>
                   </li>
                   <li className='mdc-list-item' tabIndex='0'>
                     <span className='mdc-list-item__graphic'>
@@ -335,7 +335,23 @@ class ConfirmationDialog extends Component {
                         </div>
                       </div>
                     </span>
-                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-2'>Option 2</label>
+                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-2'>Hot Cross Buns</label>
+                  </li>
+                  <li className='mdc-list-item' tabIndex='0'>
+                    <span className='mdc-list-item__graphic'>
+                      <div className='mdc-radio'>
+                        <input className='mdc-radio__native-control'
+                               type='radio'
+                               id='test-dialog-baseline-confirmation-radio-3'
+                               name='test-dialog-baseline-confirmation-radio-group'
+                               value='3'/>
+                        <div className='mdc-radio__background'>
+                          <div className='mdc-radio__outer-circle'></div>
+                          <div className='mdc-radio__inner-circle'></div>
+                        </div>
+                      </div>
+                    </span>
+                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-3'>None</label>
                   </li>
                 </ul>
               </section>

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -242,11 +242,11 @@ class SimpleDialog extends Component {
                     <i className='material-icons mdc-list-item__graphic'>person</i>
                     <span className='test-list-item__label'>user1@example.com</span>
                   </li>
-                  <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='user2@example.com'>
+                  <li className='mdc-list-item' data-mdc-dialog-action='user2@example.com'>
                     <i className='material-icons mdc-list-item__graphic'>person</i>
                     <span className='test-list-item__label'>user2@example.com</span>
                   </li>
-                  <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='add'>
+                  <li className='mdc-list-item' data-mdc-dialog-action='add'>
                     <i className='material-icons mdc-list-item__graphic'>add</i>
                     <span className='test-list-item__label'>Add account</span>
                   </li>
@@ -331,7 +331,7 @@ class ConfirmationDialog extends Component {
                     </span>
                     <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-1'>Never Gonna Give You Up</label>
                   </li>
-                  <li className='mdc-list-item' tabIndex='0'>
+                  <li className='mdc-list-item'>
                     <span className='mdc-list-item__graphic'>
                       <div className='mdc-radio'>
                         <input className='mdc-radio__native-control'
@@ -347,7 +347,7 @@ class ConfirmationDialog extends Component {
                     </span>
                     <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-2'>Hot Cross Buns</label>
                   </li>
-                  <li className='mdc-list-item' tabIndex='0'>
+                  <li className='mdc-list-item'>
                     <span className='mdc-list-item__graphic'>
                       <div className='mdc-radio'>
                         <input className='mdc-radio__native-control'

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -32,58 +32,82 @@ class DialogHero extends Component {
   render() {
     return (
       <div>
-        <aside id='my-mdc-dialog'
-              className='mdc-dialog mdc-dialog--open hero-demo'
-              role='alertdialog'
-              aria-labelledby='my-mdc-dialog-label'
-              aria-describedby='my-mdc-dialog-description'
-              ref={this.initDialog}
-              >
-          <div className='mdc-dialog__surface'>
-            <header className='mdc-dialog__header'>
-              <h2 id='my-mdc-dialog-label' className='mdc-dialog__header__title'>
+        <div id='my-mdc-dialog'
+             className='mdc-dialog mdc-dialog--open hero-demo'
+             role='alertdialog'
+             aria-labelledby='my-mdc-dialog-label'
+             aria-describedby='my-mdc-dialog-description'
+             ref={this.initDialog}
+             >
+          <div className='mdc-dialog__container'>
+            <div className='mdc-dialog__surface'>
+              <h2 id='my-mdc-dialog-label' className='mdc-dialog__title'>
                 Get this party started?
               </h2>
-            </header>
-            <section id='my-mdc-dialog-description' className='mdc-dialog__body'>
-              Turn up the jams and have a good time.
-            </section>
-            <footer className='mdc-dialog__footer'>
-              <button type='button' className='mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel'>Decline</button>
-              <button type='button' className='mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept'>Accept</button>
-            </footer>
+              <section id='my-mdc-dialog-description' className='mdc-dialog__content'>
+                Turn up the jams and have a good time.
+              </section>
+              <footer className='mdc-dialog__actions'>
+                <button type='button' className='mdc-button mdc-dialog__button'>Decline</button>
+                <button type='button' className='mdc-button mdc-dialog__button'>Accept</button>
+              </footer>
+            </div>
           </div>
-        </aside>
+        </div>
       </div>
     )
   }
 }
 
 class DialogDemos extends Component {
-  state = {open: false, hasBeenOpened: false, accepted: false};
+  state = {
+    isAlertOpen: false,
+    isSimpleOpen: false,
+    isConfirmationOpen: false,
+    isScrollableOpen: false,
+    hasBeenOpened: false,
+    accepted: false,
+  };
 
-  handleAccept_ = () => this.handleAccept();
-  handleCancel_ = () => this.handleCancel();
-  handleOpenClick_ = () => this.handleOpenClick();
+  handleAlertClick_ = this.handleAlertClick.bind(this);
+  handleSimpleClick_ = this.handleSimpleClick.bind(this);
+  handleConfirmationClick_ = this.handleConfirmationClick.bind(this);
+  handleScrollableClick_ = this.handleScrollableClick.bind(this);
+  handleClosing_ = this.handleClosing.bind(this);
 
-  handleOpenClick() {
-    this.setState({open: true});
+  handleAlertClick() {
+    this.setState({isAlertOpen: true});
   }
 
-  handleAccept() {
-    this.setState({open: false, accepted: true, hasBeenOpened: true});
+  handleSimpleClick() {
+    this.setState({isSimpleOpen: true});
   }
 
-  handleCancel() {
-    this.setState({open: false, accepted: false, hasBeenOpened: true});
+  handleConfirmationClick() {
+    this.setState({isConfirmationOpen: true});
+  }
+
+  handleScrollableClick() {
+    this.setState({isScrollableOpen: true});
+  }
+
+  handleClosing(event) {
+    this.setState({
+      isAlertOpen: false,
+      isSimpleOpen: false,
+      isConfirmationOpen: false,
+      isScrollableOpen: false,
+      accepted: event.detail.action !== 'close',
+      hasBeenOpened: true,
+    });
   }
 
   renderMessage() {
     if (this.state.hasBeenOpened) {
       return <p className='mdc-typography--body1'>
         {this.state.accepted
-          ? 'Accepted reading my novel, thanks!'
-          : 'Declined to read my novel... Maybe next time?'
+          ? 'Accepted, thanks!'
+          : 'Declined... Maybe next time?'
         }
       </p>
     }
@@ -92,18 +116,22 @@ class DialogDemos extends Component {
   render() {
     return (
       <div>
-        <h3 className='mdc-typography--subtitle1'>Scrollable Dialog</h3>
-        <Dialog open={this.state.open} handleAccept={this.handleAccept_} handleCancel={this.handleCancel_}/>
-        <button className='mdc-button' onClick={this.handleOpenClick_}>Open dialog</button>
+        <AlertDialog open={this.state.isAlertOpen} handleClosing={this.handleClosing_}/>
+        <SimpleDialog open={this.state.isSimpleOpen} handleClosing={this.handleClosing_}/>
+        <ConfirmationDialog open={this.state.isConfirmationOpen} handleClosing={this.handleClosing_}/>
+        <ScrollableDialog open={this.state.isScrollableOpen} handleClosing={this.handleClosing_}/>
+        <button className='mdc-button' onClick={this.handleAlertClick_}>Alert</button>
+        <button className='mdc-button' onClick={this.handleSimpleClick_}>Simple</button>
+        <button className='mdc-button' onClick={this.handleConfirmationClick_}>Confirmation</button>
+        <button className='mdc-button' onClick={this.handleScrollableClick_}>Scrollable</button>
         {this.renderMessage()}
       </div>
     )
   }
 }
 
-class Dialog extends Component {
-  handleAccept_ = () => this.handleAccept();
-  handleCancel_ = () => this.handleCancel();
+class AlertDialog extends Component {
+  handleClosing_ = this.handleClosing.bind(this);
   initDialog = (dialogEl) => {
     if (!dialogEl) return;
     this.dialogEl = dialogEl;
@@ -111,66 +139,280 @@ class Dialog extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.open !== this.props.open) {
-      !!this.props.open
-        ? this.dialog.show()
-        : this.dialog.close();
+    if (!prevProps.open && this.props.open) {
+      // Handle transitioning from closed to open; dialog will handle closing itself
+      this.dialog.open();
     }
   }
 
   componentDidMount() {
-    this.dialogEl.addEventListener('MDCDialog:accept', this.handleAccept_);
-    this.dialogEl.addEventListener('MDCDialog:cancel', this.handleCancel_);
+    this.dialogEl.addEventListener('MDCDialog:closing', this.handleClosing_);
   }
 
   componentWillUnmount() {
-    this.dialogEl.removeEventListener('MDCDialog:accept', this.handleAccept_);
-    this.dialogEl.removeEventListener('MDCDialog:cancel', this.handleCancel_);
+    this.dialogEl.removeEventListener('MDCDialog:closing', this.handleClosing_);
     this.dialog.destroy();
   }
 
-  handleAccept() {
-    this.props.handleAccept();
-  }
-
-  handleCancel() {
-    this.props.handleCancel();
+  handleClosing(event) {
+    this.props.handleClosing(event);
   }
 
   render() {
     return (
       <div>
-        <aside id='mdc-dialog-with-list'
-              className='mdc-dialog'
-              role='alertdialog'
-              aria-labelledby='mdc-dialog-with-list-label'
-              aria-describedby='mdc-dialog-with-list-description'
-              ref={this.initDialog}>
-          <div className='mdc-dialog__surface'>
-            <header className='mdc-dialog__header'>
-              <h2 id='mdc-dialog-with-list-label' className='mdc-dialog__header__title'>
-                Read my novel?
-              </h2>
-            </header>
-            <section id='mdc-dialog-with-list-description' className='mdc-dialog__body mdc-dialog__body--scrollable'>
-              <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Necessitatibus, incidunt. Debitis, repudiandae dignissimos et quam velit autem mollitia tenetur, eligendi rerum repellendus, explicabo ad aperiam vel ipsam! Exercitationem, voluptates molestiae.</p>
-              <p>Iusto reiciendis mollitia ab commodi. Animi maiores nesciunt officia enim corrupti officiis consequuntur vel, consectetur eveniet ad dolorum reprehenderit similique qui deleniti ut sed explicabo id error at. Laudantium, excepturi!</p>
-              <p>Suscipit quam laboriosam animi quasi similique voluptatem molestiae voluptas sint itaque, labore eos, maiores harum qui totam libero amet nisi? Similique nihil veritatis aspernatur molestias accusantium, eius dolorum autem optio?</p>
-              <p>Cum eligendi consequuntur voluptas. Repellat nisi commodi numquam aliquam quasi tenetur obcaecati, animi cum eum. Facilis esse cupiditate fugiat, quod eveniet, inventore impedit nam ex tempore harum laudantium provident assumenda.</p>
-              <p>Ut iste aperiam excepturi rerum consectetur illo officiis quo sed sunt labore earum soluta tempore omnis a, enim maiores non? Facilis qui alias sunt veniam esse hic. Aut, ducimus aliquid!</p>
-              <p>Qui quaerat saepe sunt earum nihil porro, sint quibusdam, id eos vero asperiores dolorem iusto dolore illo, architecto fuga? Voluptates distinctio eligendi nihil provident accusantium. Maxime ullam ratione officia non.</p>
-              <p>Molestiae sapiente quae nulla. Voluptates quibusdam numquam earum vero deserunt in, cum tenetur accusamus ipsum minus veniam libero quasi fuga dolorem laudantium error quo et accusantium neque vitae aliquam tempore.</p>
-              <p>Optio asperiores quisquam odit eaque incidunt laboriosam repudiandae ex eum iure quia, id vero atque perspiciatis, officiis quaerat aut ut dolorem libero eos perferendis ducimus! Veritatis nam libero tempora maxime?</p>
-              <p>Sapiente reiciendis quis eveniet iure dicta perferendis quos consectetur, soluta sunt, labore ipsam inventore maiores laudantium recusandae deleniti autem animi consequatur, voluptatem sint. Dignissimos minima labore earum vitae ad non!</p>
-              <p>Cum ex totam dolore officiis maiores quidem necessitatibus consequatur molestias culpa, quas, aperiam tempora et! Dolorem, voluptates dignissimos? Voluptatem voluptatibus expedita, error ducimus distinctio necessitatibus laudantium officiis dolorum nam vitae?</p>
-            </section>
-            <footer className='mdc-dialog__footer'>
-              <button type='button' className='mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel'>Decline</button>
-              <button type='button' className='mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept'>Accept</button>
-            </footer>
+        <div id='mdc-dialog-with-list'
+          className='mdc-dialog'
+          role='alertdialog'
+          aria-modal='true'
+          aria-labelledby='mdc-dialog-with-list-label'
+          aria-describedby='mdc-dialog-with-list-description'
+          ref={this.initDialog}>
+          <div className='mdc-dialog__scrim'></div>
+          <div className='mdc-dialog__container'>
+            <div className='mdc-dialog__surface'>
+              <section id='mdc-dialog-with-list-description' className='mdc-dialog__content'>
+                <p>Discard draft?</p>
+              </section>
+              <footer className='mdc-dialog__actions'>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='close'>Cancel</button>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='accept'>Discard</button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+class SimpleDialog extends Component {
+  handleClosing_ = this.handleClosing.bind(this);
+  initDialog = (dialogEl) => {
+    if (!dialogEl) return;
+    this.dialogEl = dialogEl;
+    this.dialog = new MDCDialog(dialogEl);
+  };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      // Handle transitioning from closed to open; dialog will handle closing itself
+      this.dialog.open();
+    }
+  }
+
+  componentDidMount() {
+    this.dialogEl.addEventListener('MDCDialog:closing', this.handleClosing_);
+  }
+
+  componentWillUnmount() {
+    this.dialogEl.removeEventListener('MDCDialog:closing', this.handleClosing_);
+    this.dialog.destroy();
+  }
+
+  handleClosing(event) {
+    this.props.handleClosing(event);
+  }
+
+  render() {
+    return (
+      <div>
+        <div id='simple-dialog'
+          className='mdc-dialog'
+          role='alertdialog'
+          aria-modal='true'
+          aria-labelledby='simple-dialog-label'
+          aria-describedby='simple-dialog-description'
+          ref={this.initDialog}>
+          <div className='mdc-dialog__scrim'></div>
+          <div className='mdc-dialog__container'>
+            <div className='mdc-dialog__surface'>
+              <h2 id='simple-dialog-label' className='mdc-dialog__title'>Select an account</h2>
+              <section id='simple-dialog-description' className='mdc-dialog__content'>
+                {
+                  // Inline `style='list-style-type: none'` needed to prevent rendering bug in Edge and IE 11.
+                  // See https://stackoverflow.com/a/23717689/467582
+                }
+                <ul className='mdc-list mdc-list--avatar-list' style={{listStyleType: 'none'}}>
+                  <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='user1@example.com'>
+                    <i className='material-icons mdc-list-item__graphic'>person</i>
+                    <span className='test-list-item__label'>user1@example.com</span>
+                  </li>
+                  <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='user2@example.com'>
+                    <i className='material-icons mdc-list-item__graphic'>person</i>
+                    <span className='test-list-item__label'>user2@example.com</span>
+                  </li>
+                  <li className='mdc-list-item' tabIndex='0' data-mdc-dialog-action='add'>
+                    <i className='material-icons mdc-list-item__graphic'>add</i>
+                    <span className='test-list-item__label'>Add account</span>
+                  </li>
+                </ul>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+class ConfirmationDialog extends Component {
+  handleClosing_ = this.handleClosing.bind(this);
+  initDialog = (dialogEl) => {
+    if (!dialogEl) return;
+    this.dialogEl = dialogEl;
+    this.dialog = new MDCDialog(dialogEl);
+  };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      // Handle transitioning from closed to open; dialog will handle closing itself
+      this.dialog.open();
+    }
+  }
+
+  componentDidMount() {
+    this.dialogEl.addEventListener('MDCDialog:closing', this.handleClosing_);
+  }
+
+  componentWillUnmount() {
+    this.dialogEl.removeEventListener('MDCDialog:closing', this.handleClosing_);
+    this.dialog.destroy();
+  }
+
+  handleClosing(event) {
+    this.props.handleClosing(event);
+  }
+
+  render() {
+    return (
+      <div>
+        <div id='simple-dialog'
+          className='mdc-dialog'
+          role='alertdialog'
+          aria-modal='true'
+          aria-labelledby='simple-dialog-label'
+          aria-describedby='simple-dialog-description'
+          ref={this.initDialog}>
+          <div className='mdc-dialog__scrim'></div>
+          <div className='mdc-dialog__container'>
+            <div className='mdc-dialog__surface'>
+              <h2 id='simple-dialog-label' className='mdc-dialog__title'>Select an account</h2>
+              <section id='simple-dialog-description' className='mdc-dialog__content'>
+                {
+                  // Inline `style='list-style-type: none'` needed to prevent rendering bug in Edge and IE 11.
+                  // See https://stackoverflow.com/a/23717689/467582
+                }
+                <ul className='mdc-list' style={{listStyleType: 'none'}}>
+                  <li className='mdc-list-item' tabIndex='0'>
+                    <span className='mdc-list-item__graphic'>
+                      <div className='mdc-radio'>
+                        <input className='mdc-radio__native-control'
+                               type='radio'
+                               id='test-dialog-baseline-confirmation-radio-1'
+                               name='test-dialog-baseline-confirmation-radio-group'
+                               value='1'
+                               defaultChecked/>
+                        <div className='mdc-radio__background'>
+                          <div className='mdc-radio__outer-circle'></div>
+                          <div className='mdc-radio__inner-circle'></div>
+                        </div>
+                      </div>
+                    </span>
+                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-1'>Option 1</label>
+                  </li>
+                  <li className='mdc-list-item' tabIndex='0'>
+                    <span className='mdc-list-item__graphic'>
+                      <div className='mdc-radio'>
+                        <input className='mdc-radio__native-control'
+                               type='radio'
+                               id='test-dialog-baseline-confirmation-radio-2'
+                               name='test-dialog-baseline-confirmation-radio-group'
+                               value='2'/>
+                        <div className='mdc-radio__background'>
+                          <div className='mdc-radio__outer-circle'></div>
+                          <div className='mdc-radio__inner-circle'></div>
+                        </div>
+                      </div>
+                    </span>
+                    <label className='test-list-item__label' htmlFor='test-dialog-baseline-confirmation-radio-2'>Option 2</label>
+                  </li>
+                </ul>
+              </section>
+              <footer className='mdc-dialog__actions'>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='close'>Cancel</button>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='accept'>OK</button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+class ScrollableDialog extends Component {
+  handleClosing_ = this.handleClosing.bind(this);
+  initDialog = (dialogEl) => {
+    if (!dialogEl) return;
+    this.dialogEl = dialogEl;
+    this.dialog = new MDCDialog(dialogEl);
+  };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      // Handle transitioning from closed to open; dialog will handle closing itself
+      this.dialog.open();
+    }
+  }
+
+  componentDidMount() {
+    this.dialogEl.addEventListener('MDCDialog:closing', this.handleClosing_);
+  }
+
+  componentWillUnmount() {
+    this.dialogEl.removeEventListener('MDCDialog:closing', this.handleClosing_);
+    this.dialog.destroy();
+  }
+
+  handleClosing(event) {
+    this.props.handleClosing(event);
+  }
+
+  render() {
+    return (
+      <div>
+        <div id='mdc-dialog-with-list'
+          className='mdc-dialog'
+          role='alertdialog'
+          aria-modal='true'
+          aria-labelledby='mdc-dialog-with-list-label'
+          aria-describedby='mdc-dialog-with-list-description'
+          ref={this.initDialog}>
+          <div className='mdc-dialog__scrim'></div>
+          <div className='mdc-dialog__container'>
+            <div className='mdc-dialog__surface'>
+              <h2 id='mdc-dialog-with-list-label' className='mdc-dialog__title'>Read my novel?</h2>
+              <section id='mdc-dialog-with-list-description' className='mdc-dialog__content'>
+                <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Necessitatibus, incidunt. Debitis, repudiandae dignissimos et quam velit autem mollitia tenetur, eligendi rerum repellendus, explicabo ad aperiam vel ipsam! Exercitationem, voluptates molestiae.</p>
+                <p>Iusto reiciendis mollitia ab commodi. Animi maiores nesciunt officia enim corrupti officiis consequuntur vel, consectetur eveniet ad dolorum reprehenderit similique qui deleniti ut sed explicabo id error at. Laudantium, excepturi!</p>
+                <p>Suscipit quam laboriosam animi quasi similique voluptatem molestiae voluptas sint itaque, labore eos, maiores harum qui totam libero amet nisi? Similique nihil veritatis aspernatur molestias accusantium, eius dolorum autem optio?</p>
+                <p>Cum eligendi consequuntur voluptas. Repellat nisi commodi numquam aliquam quasi tenetur obcaecati, animi cum eum. Facilis esse cupiditate fugiat, quod eveniet, inventore impedit nam ex tempore harum laudantium provident assumenda.</p>
+                <p>Ut iste aperiam excepturi rerum consectetur illo officiis quo sed sunt labore earum soluta tempore omnis a, enim maiores non? Facilis qui alias sunt veniam esse hic. Aut, ducimus aliquid!</p>
+                <p>Qui quaerat saepe sunt earum nihil porro, sint quibusdam, id eos vero asperiores dolorem iusto dolore illo, architecto fuga? Voluptates distinctio eligendi nihil provident accusantium. Maxime ullam ratione officia non.</p>
+                <p>Molestiae sapiente quae nulla. Voluptates quibusdam numquam earum vero deserunt in, cum tenetur accusamus ipsum minus veniam libero quasi fuga dolorem laudantium error quo et accusantium neque vitae aliquam tempore.</p>
+                <p>Optio asperiores quisquam odit eaque incidunt laboriosam repudiandae ex eum iure quia, id vero atque perspiciatis, officiis quaerat aut ut dolorem libero eos perferendis ducimus! Veritatis nam libero tempora maxime?</p>
+                <p>Sapiente reiciendis quis eveniet iure dicta perferendis quos consectetur, soluta sunt, labore ipsam inventore maiores laudantium recusandae deleniti autem animi consequatur, voluptatem sint. Dignissimos minima labore earum vitae ad non!</p>
+                <p>Cum ex totam dolore officiis maiores quidem necessitatibus consequatur molestias culpa, quas, aperiam tempora et! Dolorem, voluptates dignissimos? Voluptatem voluptatibus expedita, error ducimus distinctio necessitatibus laudantium officiis dolorum nam vitae?</p>
+              </section>
+              <footer className='mdc-dialog__actions'>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='close'>Decline</button>
+                <button type='button' className='mdc-button mdc-dialog__button' data-mdc-dialog-action='accept'>Accept</button>
+              </footer>
+            </div>
           </div>
           <div className='mdc-dialog__backdrop'></div>
-        </aside>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Adds examples from the spec to the dialog page: Alert, Simple, Confirmation, and Scrollable.

![image](https://user-images.githubusercontent.com/409245/45898635-61961980-bd8f-11e8-86d4-168d9157a991.png)