### PR TITLE
chore: Explicitly reference index.js under MDC packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow these steps to add a new component to the MDC Web demo catalog.
 ```js
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCFoo} from '@material/foo';
+import {MDCFoo} from '@material/foo/index';
 
 import './styles/FooCatalog.scss';
 

--- a/src/ButtonCatalog.js
+++ b/src/ButtonCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 
 import './styles/ButtonCatalog.scss';
 

--- a/src/CardCatalog.js
+++ b/src/CardCatalog.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import classnames from 'classnames';
-import {MDCIconButtonToggle} from '@material/icon-button';
-import {MDCRipple} from '@material/ripple';
+import {MDCIconButtonToggle} from '@material/icon-button/index';
+import {MDCRipple} from '@material/ripple/index';
 import {imagePath} from './constants';
 
 import './styles/CardCatalog.scss';

--- a/src/CheckboxCatalog.js
+++ b/src/CheckboxCatalog.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCCheckbox} from '@material/checkbox/dist/mdc.checkbox';
+import {MDCCheckbox} from '@material/checkbox/index';
 
 import './styles/CheckboxCatalog.scss';
 

--- a/src/ChipsCatalog.js
+++ b/src/ChipsCatalog.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCChipSet} from '@material/chips';
+import {MDCChipSet} from '@material/chips/index';
 
 import './styles/ChipsCatalog.scss';
 

--- a/src/ComponentCatalogPanel.js
+++ b/src/ComponentCatalogPanel.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {imagePath} from './constants';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 
 // ComponentCatalogPanel is the container for catalog component content,
 // that renders the hero and demo sections.

--- a/src/ComponentImageList.js
+++ b/src/ComponentImageList.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 import {Link} from 'react-router-dom';
 
 import buttonImg from './images/buttons_180px.svg';

--- a/src/ComponentSidebar.js
+++ b/src/ComponentSidebar.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import classnames from 'classnames';
-import {MDCDrawer} from '@material/drawer';
-import {MDCRipple} from '@material/ripple';
+import {MDCDrawer} from '@material/drawer/index';
+import {MDCRipple} from '@material/ripple/index';
 import {imagePath} from './constants';
 
 const SCREEN_WIDTH_BREAKPOINT = 1160;

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCDialog} from '@material/dialog/dist/mdc.dialog';
-import {MDCList} from '@material/list/dist/mdc.list';
+import {MDCDialog} from '@material/dialog/index';
+import {MDCList} from '@material/list/index';
 
 import './styles/DialogCatalog.scss';
 

--- a/src/DrawerCatalog.js
+++ b/src/DrawerCatalog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 
-import {MDCRipple} from '@material/ripple/dist/mdc.ripple';
+import {MDCRipple} from '@material/ripple/index';
 import {MDCList} from '@material/list/index';
 import './styles/DrawerCatalog.scss';
 

--- a/src/FabCatalog.js
+++ b/src/FabCatalog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import classnames from 'classnames';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 
 import './styles/FabCatalog.scss';
 

--- a/src/FormField.js
+++ b/src/FormField.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import classnames from 'classnames';
-import {MDCFormField} from '@material/form-field';
+import {MDCFormField} from '@material/form-field/index';
 
 import './styles/FormField.scss';
 

--- a/src/HeaderBar.js
+++ b/src/HeaderBar.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 
 import './styles/HeaderBar.scss';
-import {MDCTopAppBar} from '@material/top-app-bar';
+import {MDCTopAppBar} from '@material/top-app-bar/index';
 import {imagePath} from './constants';
 
 class HeaderBar extends Component {

--- a/src/IconButtonCatalog.js
+++ b/src/IconButtonCatalog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCIconButtonToggle} from '@material/icon-button';
-import {MDCRipple} from '@material/ripple';
+import {MDCIconButtonToggle} from '@material/icon-button/index';
+import {MDCRipple} from '@material/ripple/index';
 
 import './styles/IconButtonCatalog.scss';
 

--- a/src/LinearProgressIndicatorCatalog.js
+++ b/src/LinearProgressIndicatorCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCLinearProgress} from '@material/linear-progress/dist/mdc.linearProgress';
+import {MDCLinearProgress} from '@material/linear-progress/index';
 
 import './styles/LinearProgressIndicatorCatalog.scss';
 

--- a/src/ListCatalog.js
+++ b/src/ListCatalog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {MDCList} from '@material/list/index';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 import classnames from 'classnames';
 
 import './styles/ListCatalog.scss';

--- a/src/MenuCatalog.js
+++ b/src/MenuCatalog.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCMenu} from '@material/menu';
-import {MDCRipple} from '@material/ripple';
+import {MDCMenu} from '@material/menu/index';
+import {MDCRipple} from '@material/ripple/index';
 
 import './styles/MenuCatalog.scss';
 

--- a/src/RadioButtonCatalog.js
+++ b/src/RadioButtonCatalog.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {withFormField} from './FormField';
-import {MDCRadio} from '@material/radio';
+import {MDCRadio} from '@material/radio/index';
 
 import './styles/RadioButtonCatalog.scss';
 

--- a/src/RippleCatalog.js
+++ b/src/RippleCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCRipple} from '@material/ripple';
+import {MDCRipple} from '@material/ripple/index';
 
 import './styles/RippleCatalog.scss';
 

--- a/src/SelectCatalog.js
+++ b/src/SelectCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCSelect} from '@material/select/dist/mdc.select';
+import {MDCSelect} from '@material/select/index';
 
 import './styles/SelectCatalog.scss';
 

--- a/src/SliderCatalog.js
+++ b/src/SliderCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCSlider} from '@material/slider';
+import {MDCSlider} from '@material/slider/index';
 
 import './styles/SliderCatalog.scss';
 

--- a/src/SnackbarCatalog.js
+++ b/src/SnackbarCatalog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCSnackbar} from '@material/snackbar/dist/mdc.snackbar';
+import {MDCSnackbar} from '@material/snackbar/index';
 import classnames from 'classnames';
 
 import './styles/SnackbarCatalog.scss';
@@ -61,12 +61,12 @@ class SnackbarDemo extends Component {
         <button className='mdc-button mdc-button--raised snackbar-demo-button' onClick={this.handleShowClick}>
           Show snackbar
         </button>
-        <button className='mdc-button mdc-button--raised snackbar-demo-button' 
+        <button className='mdc-button mdc-button--raised snackbar-demo-button'
                 onClick={this.handleShowStartAlignedClick}>
           Show start aligned
         </button>
         <Snackbar show={this.state.showSnackbar} handleShown={this.handleSnackbarShown}/>
-        <Snackbar show={this.state.showStartAlignedSnackbar} startAligned={true} 
+        <Snackbar show={this.state.showStartAlignedSnackbar} startAligned={true}
                   handleShown={this.handleShowStartAlignedSnackbarShown}/>
       </div>
     )
@@ -109,7 +109,7 @@ class Snackbar extends Component {
         <div className='mdc-snackbar__action-wrapper'>
           <button type='button' className='mdc-snackbar__action-button'></button>
         </div>
-      </div>    
+      </div>
     )
   }
 }

--- a/src/SwitchCatalog.js
+++ b/src/SwitchCatalog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import classnames from 'classnames';
-import {MDCSwitch} from '@material/switch';
+import {MDCSwitch} from '@material/switch/index';
 
 import './styles/SwitchCatalog.scss';
 

--- a/src/TabsCatalog.js
+++ b/src/TabsCatalog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCTabBar} from '@material/tab-bar';
+import {MDCTabBar} from '@material/tab-bar/index';
 
 import './styles/TabsCatalog.scss';
 

--- a/src/TextFieldCatalog.js
+++ b/src/TextFieldCatalog.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCTextField} from '@material/textfield';
+import {MDCTextField} from '@material/textfield/index';
 import classnames from 'classnames';
 
 import './styles/TextFieldCatalog.scss';

--- a/src/ThemeCatalog.js
+++ b/src/ThemeCatalog.js
@@ -1,12 +1,12 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
-import {MDCCheckbox} from '@material/checkbox';
-import {MDCIconButtonToggle} from '@material/icon-button';
-import {MDCLinearProgress} from '@material/linear-progress';
-import {MDCRipple} from '@material/ripple';
-import {MDCSelect} from '@material/select';
-import {MDCSlider} from '@material/slider';
-import {MDCTextField} from '@material/textfield';
+import {MDCCheckbox} from '@material/checkbox/index';
+import {MDCIconButtonToggle} from '@material/icon-button/index';
+import {MDCLinearProgress} from '@material/linear-progress/index';
+import {MDCRipple} from '@material/ripple/index';
+import {MDCSelect} from '@material/select/index';
+import {MDCSlider} from '@material/slider/index';
+import {MDCTextField} from '@material/textfield/index';
 import {imagePath} from './constants';
 
 import './styles/ThemeCatalog.scss';

--- a/src/TopAppBarCatalog.js
+++ b/src/TopAppBarCatalog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 
-import {MDCRipple} from '@material/ripple/dist/mdc.ripple';
+import {MDCRipple} from '@material/ripple/index';
 import './styles/TopAppBarCatalog.scss';
 
 const TopAppBarCatalog = (props) => {

--- a/src/frame/DrawerFramePage.js
+++ b/src/frame/DrawerFramePage.js
@@ -1,6 +1,6 @@
 import {MDCTopAppBar} from '@material/top-app-bar/index';
 import {MDCList} from '@material/list/index';
-import {MDCDrawer} from '@material/drawer';
+import {MDCDrawer} from '@material/drawer/index';
 
 import React, {Component} from 'react';
 


### PR DESCRIPTION
Currently we have a mix of MDC imports that explicitly reference `index`, explicitly reference `dist/mdc.*.js`, and others that just import the package root.

This PR updates so that everything references `index`, since I already configured our toolchain to process MDC's code through babel back in #43. It saves roughly 17KB in the minified/gzipped JS produced by the build on master, and will save more in future releases when considering that https://github.com/material-components/material-components-web/pull/3245 will change the behavior of package-root imports.