### PR TITLE
feat: Add routes to just render Hero components for material.io experiments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import TopAppBarFramePage from './frame/TopAppBarFramePage';
 import DrawerFramePage from './frame/DrawerFramePage';
 
 import './styles/App.scss';
+import IFrameRoutes from './IFrameRoutes';
 
 class App extends Component {
   componentWillReceiveProps(nextProps) {
@@ -20,6 +21,7 @@ class App extends Component {
       <Switch>
         <Route path='/component/drawer/:type' component={DrawerFramePage} />
         <Route path='/component/top-app-bar/:type' component={TopAppBarFramePage} />
+        <Route path='/component/iframe/:type' component={withRouter(props => <IFrameRoutes {...props} />)} />
         <Route path='/' component={CatalogPage} />
       </Switch>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
       <Switch>
         <Route path='/component/drawer/:type' component={DrawerFramePage} />
         <Route path='/component/top-app-bar/:type' component={TopAppBarFramePage} />
-        <Route path='/component/iframe/:type' component={withRouter(props => <IFrameRoutes {...props} />)} />
+        <Route path='/component/iframe/:type' component={IFrameRoutes} />
         <Route path='/' component={CatalogPage} />
       </Switch>
     );

--- a/src/ButtonCatalog.js
+++ b/src/ButtonCatalog.js
@@ -18,7 +18,7 @@ const ButtonCatalog = () => {
   );
 }
 
-class ButtonHero extends Component {
+export class ButtonHero extends Component {
   constructor(props) {
     super(props);
     this.ripples = [];

--- a/src/CardCatalog.js
+++ b/src/CardCatalog.js
@@ -10,7 +10,7 @@ import './styles/CardCatalog.scss';
 const CardCatalog = () => {
   return (
     <ComponentCatalogPanel
-      hero={<Card image actions className='demo-card--hero' />}
+      hero={<CardHero/>}
       title='Card'
       description='Cards contain content and actions about a single subject.'
       designLink='https://material.io/go/design-cards'
@@ -20,6 +20,12 @@ const CardCatalog = () => {
     />
   );
 };
+
+export class CardHero extends Component {
+  render() {
+    return (<Card image actions className='demo-card--hero' />);
+  }
+}
 
 class Card extends Component {
   componentWillUnmount() {

--- a/src/CardCatalog.js
+++ b/src/CardCatalog.js
@@ -21,11 +21,9 @@ const CardCatalog = () => {
   );
 };
 
-export class CardHero extends Component {
-  render() {
-    return (<Card image actions className='demo-card--hero' />);
-  }
-}
+export const CardHero = () => {
+  return (<Card image actions className='demo-card--hero' />);
+};
 
 class Card extends Component {
   componentWillUnmount() {

--- a/src/CheckboxCatalog.js
+++ b/src/CheckboxCatalog.js
@@ -18,7 +18,7 @@ const CheckboxCatalog = () => {
   );
 }
 
-class CheckboxHero extends Component {
+export class CheckboxHero extends Component {
   constructor(props) {
     super(props);
     this.checkboxes = [];

--- a/src/ChipsCatalog.js
+++ b/src/ChipsCatalog.js
@@ -18,7 +18,7 @@ const ChipsCatalog = () => {
   );
 }
 
-class ChipsHero extends Component {
+export class ChipsHero extends Component {
   constructor(props) {
     super(props);
     this.chipSet = null;

--- a/src/DialogCatalog.js
+++ b/src/DialogCatalog.js
@@ -19,7 +19,7 @@ const DialogCatalog = () => {
   );
 };
 
-class DialogHero extends Component {
+export class DialogHero extends Component {
   initDialog = (dialogEl) => {
     if (!dialogEl) return;
     this.dialogEl = dialogEl;

--- a/src/DrawerCatalog.js
+++ b/src/DrawerCatalog.js
@@ -19,7 +19,7 @@ const DrawerCatalog = (props) => {
   );
 };
 
-class DrawerHero extends Component {
+export class DrawerHero extends Component {
   ripples = [];
   list = {};
   initRipple = icon => {

--- a/src/ElevationCatalog.js
+++ b/src/ElevationCatalog.js
@@ -18,7 +18,8 @@ const ElevationCatalog = () => {
     />
   );
 };
-class ElevationHero extends Component {
+
+export class ElevationHero extends Component {
   render() {
     return (
         <div className='elevation-hero'>

--- a/src/FabCatalog.js
+++ b/src/FabCatalog.js
@@ -84,15 +84,13 @@ const FabDemos = () => (
   </div>
 );
 
-export class FabHero extends Component {
-  render() {
-    return (
-        <Fab ariaLabel='Favorite'>
-          <i className='mdc-fab__icon material-icons'>favorite_border</i>
-        </Fab>
-    );
-  }
-}
+export const FabHero = () => {
+  return (
+      <Fab ariaLabel='Favorite'>
+        <i className='mdc-fab__icon material-icons'>favorite_border</i>
+      </Fab>
+  );
+};
 
 const FabCatalog = () => {
   const description = 'Floating action buttons represents the primary action in an application. '

--- a/src/FabCatalog.js
+++ b/src/FabCatalog.js
@@ -84,16 +84,22 @@ const FabDemos = () => (
   </div>
 );
 
+export class FabHero extends Component {
+  render() {
+    return (
+        <Fab ariaLabel='Favorite'>
+          <i className='mdc-fab__icon material-icons'>favorite_border</i>
+        </Fab>
+    );
+  }
+}
+
 const FabCatalog = () => {
   const description = 'Floating action buttons represents the primary action in an application. '
     + 'Only one floating action button is recommended per screen to represent the most common action.';
   return (
     <ComponentCatalogPanel
-      hero={
-        <Fab ariaLabel='Favorite'>
-          <i className='mdc-fab__icon material-icons'>favorite_border</i>
-        </Fab>
-      }
+      hero={<FabHero/>}
       title='Floating Action Button'
       description={description}
       designLink='https://material.io/go/design-fab'

--- a/src/IFrameRoutes.js
+++ b/src/IFrameRoutes.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import {Route} from 'react-router-dom';
+import {ButtonHero} from './ButtonCatalog';
+import {CardHero} from './CardCatalog';
+import {CheckboxHero} from './CheckboxCatalog';
+import {ChipsHero} from './ChipsCatalog';
+import {DialogHero} from './DialogCatalog';
+import {DrawerHero} from './DrawerCatalog';
+import {ElevationHero} from './ElevationCatalog';
+import {FabHero} from './FabCatalog';
+import {IconButtonHero} from './IconButtonCatalog';
+import {ImageListHero} from './ImageListCatalog';
+import {LayoutGridHero} from './LayoutGridCatalog';
+import {ListHero} from './ListCatalog';
+import {MenuHero} from './MenuCatalog';
+import {RadioButtonHero} from './RadioButtonCatalog';
+import {RippleHero} from './RippleCatalog';
+import {SelectHero} from './SelectCatalog';
+import {SliderHero} from './SliderCatalog';
+import {SnackbarHero} from './SnackbarCatalog';
+import {SwitchHero} from './SwitchCatalog';
+import {TabsHero} from './TabsCatalog';
+import {TextFieldHero} from './TextFieldCatalog';
+import {TopAppBarHero} from './TopAppBarCatalog';
+import {TypographyHero} from './TypographyCatalog';
+import {LinearProgressHero} from './LinearProgressIndicatorCatalog';
+import { matchPath } from 'react-router';
+
+const routesList = [{
+  urlPath: 'button',
+  Component: ButtonHero,
+}, {
+  urlPath: 'card',
+  Component: CardHero,
+}, {
+  urlPath: 'checkbox',
+  Component: CheckboxHero,
+}, {
+  urlPath: 'chips',
+  Component: ChipsHero,
+}, {
+  urlPath: 'dialog',
+  Component: DialogHero,
+}, {
+  urlPath: 'drawer',
+  Component: DrawerHero,
+}, {
+  urlPath: 'elevation',
+  Component: ElevationHero,
+}, {
+  urlPath: 'fab',
+  Component: FabHero,
+}, {
+  urlPath: 'icon-button',
+  Component: IconButtonHero,
+}, {
+  urlPath: 'image-list',
+  Component: ImageListHero,
+}, {
+  urlPath: 'layout-grid',
+  Component: LayoutGridHero,
+}, {
+  urlPath: 'list',
+  Component: ListHero,
+}, {
+  urlPath: 'linear-progress-indicator',
+  Component: LinearProgressHero,
+}, {
+  urlPath: 'menu',
+  Component: MenuHero,
+}, {
+  urlPath: 'radio',
+  Component: RadioButtonHero,
+}, {
+  urlPath: 'ripple',
+  Component: RippleHero,
+}, {
+  urlPath: 'select',
+  Component: SelectHero,
+}, {
+  urlPath: 'slider',
+  Component: SliderHero,
+}, {
+  urlPath: 'snackbar',
+  Component: SnackbarHero,
+}, {
+  urlPath: 'switch',
+  Component: SwitchHero,
+}, {
+  urlPath: 'tabs',
+  Component: TabsHero,
+}, {
+  urlPath: 'text-field',
+  Component: TextFieldHero,
+}, {
+  urlPath: 'top-app-bar',
+  Component: TopAppBarHero,
+}, {
+  urlPath: 'typography',
+  Component: TypographyHero,
+}];
+
+const IFrameRoutes = (props) => {
+  return (
+    routesList.map((route) => {
+      const {Component, urlPath} = route;
+      if (!matchPath(props.location.pathname, `/component/iframe/${urlPath}`)) return;
+      return (
+          <div className='hero'
+               key={urlPath}>
+            <Route
+                path={`/component/iframe/${urlPath}`}
+                render={(props) => <Component {...props}/>} />
+          </div>
+      );
+    })
+  );
+};
+
+export default IFrameRoutes;

--- a/src/IFrameRoutes.js
+++ b/src/IFrameRoutes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Route} from 'react-router-dom';
+import {Route, withRouter} from 'react-router-dom';
 import {ButtonHero} from './ButtonCatalog';
 import {CardHero} from './CardCatalog';
 import {CheckboxHero} from './CheckboxCatalog';
@@ -24,7 +24,6 @@ import {TextFieldHero} from './TextFieldCatalog';
 import {TopAppBarHero} from './TopAppBarCatalog';
 import {TypographyHero} from './TypographyCatalog';
 import {LinearProgressHero} from './LinearProgressIndicatorCatalog';
-import { matchPath } from 'react-router';
 
 const routesList = [{
   urlPath: 'button',
@@ -104,17 +103,19 @@ const IFrameRoutes = (props) => {
   return (
     routesList.map((route) => {
       const {Component, urlPath} = route;
-      if (!matchPath(props.location.pathname, `/component/iframe/${urlPath}`)) return;
       return (
-          <div className='hero'
-               key={urlPath}>
             <Route
+                exact
+                key={urlPath}
                 path={`/component/iframe/${urlPath}`}
-                render={(props) => <Component {...props}/>} />
-          </div>
+                render={(props) => (
+                    <div className='hero'>
+                      <Component {...props}/>
+                    </div>)
+                } />
       );
     })
   );
 };
 
-export default IFrameRoutes;
+export default withRouter(IFrameRoutes);

--- a/src/IFrameRoutes.js
+++ b/src/IFrameRoutes.js
@@ -11,6 +11,7 @@ import {FabHero} from './FabCatalog';
 import {IconButtonHero} from './IconButtonCatalog';
 import {ImageListHero} from './ImageListCatalog';
 import {LayoutGridHero} from './LayoutGridCatalog';
+import {LinearProgressHero} from './LinearProgressIndicatorCatalog';
 import {ListHero} from './ListCatalog';
 import {MenuHero} from './MenuCatalog';
 import {RadioButtonHero} from './RadioButtonCatalog';
@@ -22,8 +23,6 @@ import {SwitchHero} from './SwitchCatalog';
 import {TabsHero} from './TabsCatalog';
 import {TextFieldHero} from './TextFieldCatalog';
 import {TopAppBarHero} from './TopAppBarCatalog';
-import {TypographyHero} from './TypographyCatalog';
-import {LinearProgressHero} from './LinearProgressIndicatorCatalog';
 
 const routesList = [{
   urlPath: 'button',
@@ -59,11 +58,11 @@ const routesList = [{
   urlPath: 'layout-grid',
   Component: LayoutGridHero,
 }, {
-  urlPath: 'list',
-  Component: ListHero,
-}, {
   urlPath: 'linear-progress-indicator',
   Component: LinearProgressHero,
+}, {
+  urlPath: 'list',
+  Component: ListHero,
 }, {
   urlPath: 'menu',
   Component: MenuHero,
@@ -94,9 +93,6 @@ const routesList = [{
 }, {
   urlPath: 'top-app-bar',
   Component: TopAppBarHero,
-}, {
-  urlPath: 'typography',
-  Component: TypographyHero,
 }];
 
 const IFrameRoutes = (props) => {

--- a/src/IconButtonCatalog.js
+++ b/src/IconButtonCatalog.js
@@ -21,13 +21,11 @@ const IconButtonCatalog = () => {
   );
 };
 
-export class IconButtonHero extends Component {
-  render() {
+export const IconButtonHero = () => {
     return (
         <IconButtonToggle />
     );
-  }
-}
+};
 
 class IconButtonToggle extends Component {
   initIconButtonToggle = (ele) => {

--- a/src/IconButtonCatalog.js
+++ b/src/IconButtonCatalog.js
@@ -10,7 +10,7 @@ const IconButtonCatalog = () => {
                       'make a selection, such as adding or removing a star to an item. ';
   return (
     <ComponentCatalogPanel
-      hero={<IconButtonToggle/>}
+      hero={<IconButtonHero/>}
       title='Icon Button'
       description={description}
       designLink='https://material.io/design/components/buttons.html#toggle-button'
@@ -20,6 +20,14 @@ const IconButtonCatalog = () => {
     />
   );
 };
+
+export class IconButtonHero extends Component {
+  render() {
+    return (
+        <IconButtonToggle />
+    );
+  }
+}
 
 class IconButtonToggle extends Component {
   initIconButtonToggle = (ele) => {

--- a/src/ImageListCatalog.js
+++ b/src/ImageListCatalog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React  from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {imagePath} from './constants';
 

--- a/src/ImageListCatalog.js
+++ b/src/ImageListCatalog.js
@@ -1,4 +1,4 @@
-import React  from 'react';
+import React from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {imagePath} from './constants';
 

--- a/src/ImageListCatalog.js
+++ b/src/ImageListCatalog.js
@@ -18,21 +18,19 @@ function ImageListCatalog() {
   );
 }
 
-export class ImageListHero extends Component {
-  render() {
-    const items = [];
-    for (let i = 0; i < 15; i++) {
-      items.push('');
-    }
-
-    return (
-        <div>
-          <ImageList className='hero-image-list' items={items}
-                     includeAspectContainer/>
-        </div>
-    );
+export const ImageListHero = () => {
+  const items = [];
+  for (let i = 0; i < 15; i++) {
+    items.push('');
   }
-}
+
+  return (
+      <div>
+        <ImageList className='hero-image-list' items={items}
+                   includeAspectContainer/>
+      </div>
+  );
+};
 
 function ImageListDemos() {
   const standardImageListItems = [];

--- a/src/ImageListCatalog.js
+++ b/src/ImageListCatalog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 import {imagePath} from './constants';
 
@@ -18,17 +18,20 @@ function ImageListCatalog() {
   );
 }
 
-function ImageListHero() {
-  const items = [];
-  for (let i = 0; i < 15; i++) {
-    items.push('');
-  }
+export class ImageListHero extends Component {
+  render() {
+    const items = [];
+    for (let i = 0; i < 15; i++) {
+      items.push('');
+    }
 
-  return (
-    <div>
-      <ImageList className='hero-image-list' items={items} includeAspectContainer />
-    </div>
-  );
+    return (
+        <div>
+          <ImageList className='hero-image-list' items={items}
+                     includeAspectContainer/>
+        </div>
+    );
+  }
 }
 
 function ImageListDemos() {

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 
@@ -17,17 +17,19 @@ const LayoutGridCatalog = () => {
   )
 };
 
-const LayoutGridHero = () => {
-  return (
-    <LayoutGrid className='demo-grid'>
-      <LayoutGridInner>
-        <LayoutGridCell className='demo-cell'></LayoutGridCell>
-        <LayoutGridCell className='demo-cell'></LayoutGridCell>
-        <LayoutGridCell className='demo-cell'></LayoutGridCell>
-      </LayoutGridInner>
-    </LayoutGrid>
-  )
-};
+export class LayoutGridHero extends Component {
+  render() {
+    return (
+        <LayoutGrid className='demo-grid'>
+          <LayoutGridInner>
+            <LayoutGridCell className='demo-cell'></LayoutGridCell>
+            <LayoutGridCell className='demo-cell'></LayoutGridCell>
+            <LayoutGridCell className='demo-cell'></LayoutGridCell>
+          </LayoutGridInner>
+        </LayoutGrid>
+    )
+  }
+}
 
 const LayoutGridDemos = () => {
   return (

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -1,4 +1,4 @@
-import React  from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React  from 'react';
 import classnames from 'classnames';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 

--- a/src/LayoutGridCatalog.js
+++ b/src/LayoutGridCatalog.js
@@ -17,19 +17,17 @@ const LayoutGridCatalog = () => {
   )
 };
 
-export class LayoutGridHero extends Component {
-  render() {
-    return (
-        <LayoutGrid className='demo-grid'>
-          <LayoutGridInner>
-            <LayoutGridCell className='demo-cell'></LayoutGridCell>
-            <LayoutGridCell className='demo-cell'></LayoutGridCell>
-            <LayoutGridCell className='demo-cell'></LayoutGridCell>
-          </LayoutGridInner>
-        </LayoutGrid>
-    )
-  }
-}
+export const LayoutGridHero = () => {
+  return (
+      <LayoutGrid className='demo-grid'>
+        <LayoutGridInner>
+          <LayoutGridCell className='demo-cell'></LayoutGridCell>
+          <LayoutGridCell className='demo-cell'></LayoutGridCell>
+          <LayoutGridCell className='demo-cell'></LayoutGridCell>
+        </LayoutGridInner>
+      </LayoutGrid>
+  )
+};
 
 const LayoutGridDemos = () => {
   return (

--- a/src/LinearProgressIndicatorCatalog.js
+++ b/src/LinearProgressIndicatorCatalog.js
@@ -18,7 +18,7 @@ const LinearProgressCatalog = () => {
   );
 }
 
-class LinearProgressHero extends Component {
+export class LinearProgressHero extends Component {
   initIndicator = (indicatorEl) => {
     if (!indicatorEl) return;
     this.indicator = new MDCLinearProgress(indicatorEl);

--- a/src/ListCatalog.js
+++ b/src/ListCatalog.js
@@ -21,15 +21,19 @@ const ListCatalog = () => (
   />
 );
 
-const ListHero = () => (
-  <div className='hero-list'>
-    <List>
-      <ListItem lineOne='Line item' />
-      <ListItem lineOne='Line item' />
-      <ListItem lineOne='Line item' />
-    </List>
-  </div>
-);
+export class ListHero extends Component {
+  render() {
+    return (
+        <div className='hero-list'>
+          <List>
+            <ListItem lineOne='Line item'/>
+            <ListItem lineOne='Line item'/>
+            <ListItem lineOne='Line item'/>
+          </List>
+        </div>
+    )
+  }
+}
 
 const ListDivider = () => (
   <li className='mdc-list-divider' role='separator'></li>

--- a/src/ListCatalog.js
+++ b/src/ListCatalog.js
@@ -21,19 +21,15 @@ const ListCatalog = () => (
   />
 );
 
-export class ListHero extends Component {
-  render() {
-    return (
-        <div className='hero-list'>
-          <List>
-            <ListItem lineOne='Line item'/>
-            <ListItem lineOne='Line item'/>
-            <ListItem lineOne='Line item'/>
-          </List>
-        </div>
-    )
-  }
-}
+export const ListHero = () => (
+  <div className='hero-list'>
+    <List>
+      <ListItem lineOne='Line item' />
+      <ListItem lineOne='Line item' />
+      <ListItem lineOne='Line item' />
+    </List>
+  </div>
+);
 
 const ListDivider = () => (
   <li className='mdc-list-divider' role='separator'></li>

--- a/src/MenuCatalog.js
+++ b/src/MenuCatalog.js
@@ -20,14 +20,16 @@ const MenuCatalog = () => {
   )
 };
 
-const MenuHero = () => {
-  return (
-    <MenuDOM defaultOpen className='hero-menu'>
-      <MenuItem name='A Menu Item' />
-      <MenuItem name='Another Menu Item' />
-    </MenuDOM>
-  );
-};
+export class MenuHero extends Component {
+  render() {
+    return (
+        <MenuDOM defaultOpen className='hero-menu'>
+          <MenuItem name='A Menu Item'/>
+          <MenuItem name='Another Menu Item'/>
+        </MenuDOM>
+    );
+  }
+}
 
 class MenuDemos extends Component {
   state = {open: false, focusIndex: undefined};

--- a/src/MenuCatalog.js
+++ b/src/MenuCatalog.js
@@ -20,16 +20,14 @@ const MenuCatalog = () => {
   )
 };
 
-export class MenuHero extends Component {
-  render() {
-    return (
-        <MenuDOM defaultOpen className='hero-menu'>
-          <MenuItem name='A Menu Item'/>
-          <MenuItem name='Another Menu Item'/>
-        </MenuDOM>
-    );
-  }
-}
+export const MenuHero = () => {
+  return (
+      <MenuDOM defaultOpen className='hero-menu'>
+        <MenuItem name='A Menu Item'/>
+        <MenuItem name='Another Menu Item'/>
+      </MenuDOM>
+  );
+};
 
 class MenuDemos extends Component {
   state = {open: false, focusIndex: undefined};

--- a/src/RadioButtonCatalog.js
+++ b/src/RadioButtonCatalog.js
@@ -20,16 +20,14 @@ const RadioButtonCatalog = () => {
   );
 }
 
-export class RadioButtonHero extends Component {
-  render() {
-    return (
-        <div>
-          <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-1' defaultChecked />
-          <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-2' />
-        </div>
-    );
-  }
-}
+export const RadioButtonHero = () => {
+  return (
+      <div>
+        <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-1' defaultChecked />
+        <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-2' />
+      </div>
+  );
+};
 
 const RadioButtonDemos = () => {
   return (

--- a/src/RadioButtonCatalog.js
+++ b/src/RadioButtonCatalog.js
@@ -20,14 +20,16 @@ const RadioButtonCatalog = () => {
   );
 }
 
-const RadioButtonHero = () => {
-  return (
-    <div>
-      <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-1' defaultChecked />
-      <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-2' />
-    </div>
-  );
-};
+export class RadioButtonHero extends Component {
+  render() {
+    return (
+        <div>
+          <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-1' defaultChecked />
+          <Radio className='demo-radio' name='hero-radio-set' id='hero-radio-2' />
+        </div>
+    );
+  }
+}
 
 const RadioButtonDemos = () => {
   return (

--- a/src/RippleCatalog.js
+++ b/src/RippleCatalog.js
@@ -16,9 +16,9 @@ const RippleCatalog = () => {
       demos={<RippleDemos />}
     />
   );
-}
+};
 
-class RippleHero extends Component {
+export class RippleHero extends Component {
   ripples = [];
   initRipple = buttonEl => buttonEl && this.ripples.push(new MDCRipple(buttonEl));
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -12,8 +12,8 @@ import FabCatalog from './FabCatalog';
 import IconButtonCatalog from './IconButtonCatalog';
 import ImageListCatalog from './ImageListCatalog';
 import LayoutGridCatalog from './LayoutGridCatalog';
-import ListCatalog from './ListCatalog';
 import LinearProgressIndicatorCatalog from './LinearProgressIndicatorCatalog';
+import ListCatalog from './ListCatalog';
 import MenuCatalog from './MenuCatalog';
 import RadioButtonCatalog from './RadioButtonCatalog';
 import RippleCatalog from './RippleCatalog';
@@ -61,11 +61,11 @@ const routesList = [{
   urlPath: 'layout-grid',
   Component: LayoutGridCatalog,
 }, {
-  urlPath: 'list',
-  Component: ListCatalog,
-}, {
   urlPath: 'linear-progress-indicator',
   Component: LinearProgressIndicatorCatalog,
+}, {
+  urlPath: 'list',
+  Component: ListCatalog,
 }, {
   urlPath: 'menu',
   Component: MenuCatalog,

--- a/src/SelectCatalog.js
+++ b/src/SelectCatalog.js
@@ -19,7 +19,7 @@ const SelectCatalog = () => {
   );
 }
 
-class SelectHero extends Component {
+export class SelectHero extends Component {
   initSelect = (selectEl) => {
     if (!selectEl) return;
     this.select = new MDCSelect(selectEl);

--- a/src/SliderCatalog.js
+++ b/src/SliderCatalog.js
@@ -16,7 +16,7 @@ const SliderCatalog = () => (
   />
 );
 
-class SliderHero extends Component {
+export class SliderHero extends Component {
   initSlider = (sliderEl) => {
     if (!sliderEl) return;
     this.slider = new MDCSlider(sliderEl);

--- a/src/SnackbarCatalog.js
+++ b/src/SnackbarCatalog.js
@@ -19,20 +19,24 @@ const SnackbarCatalog = () => {
   );
 };
 
-const SnackbarHero = () => {
-  return (
-    <div className='snackbar-hero'>
-      <div className='mdc-snackbar mdc-snackbar--active'
-          aria-live='assertive'
-          aria-atomic='true'
-          aria-hidden='true'>
-        <div className='mdc-snackbar__text'>Message Sent</div>
-        <div className='mdc-snackbar__action-wrapper'>
-          <button type='button' className='mdc-snackbar__action-button'>Undo</button>
+export class SnackbarHero extends Component {
+  render() {
+    return (
+        <div className='snackbar-hero'>
+          <div className='mdc-snackbar mdc-snackbar--active'
+               aria-live='assertive'
+               aria-atomic='true'
+               aria-hidden='true'>
+            <div className='mdc-snackbar__text'>Message Sent</div>
+            <div className='mdc-snackbar__action-wrapper'>
+              <button type='button'
+                      className='mdc-snackbar__action-button'>Undo
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
-  )
+    )
+  }
 }
 
 class SnackbarDemo extends Component {

--- a/src/SnackbarCatalog.js
+++ b/src/SnackbarCatalog.js
@@ -19,25 +19,23 @@ const SnackbarCatalog = () => {
   );
 };
 
-export class SnackbarHero extends Component {
-  render() {
-    return (
-        <div className='snackbar-hero'>
-          <div className='mdc-snackbar mdc-snackbar--active'
-               aria-live='assertive'
-               aria-atomic='true'
-               aria-hidden='true'>
-            <div className='mdc-snackbar__text'>Message Sent</div>
-            <div className='mdc-snackbar__action-wrapper'>
-              <button type='button'
-                      className='mdc-snackbar__action-button'>Undo
-              </button>
-            </div>
+export const SnackbarHero = () => {
+  return (
+      <div className='snackbar-hero'>
+        <div className='mdc-snackbar mdc-snackbar--active'
+             aria-live='assertive'
+             aria-atomic='true'
+             aria-hidden='true'>
+          <div className='mdc-snackbar__text'>Message Sent</div>
+          <div className='mdc-snackbar__action-wrapper'>
+            <button type='button'
+                    className='mdc-snackbar__action-button'>Undo
+            </button>
           </div>
         </div>
-    )
-  }
-}
+      </div>
+  )
+};
 
 class SnackbarDemo extends Component {
   state = {showSnackbar: false, showStartAlignedSnackbar: false};

--- a/src/SwitchCatalog.js
+++ b/src/SwitchCatalog.js
@@ -51,7 +51,7 @@ class Switch extends Component {
   }
 }
 
-class SwitchHero extends Component {
+export class SwitchHero extends Component {
   render() {
     return (
       <Switch inputId='hero-switch' label='off/on' defaultChecked />

--- a/src/TabsCatalog.js
+++ b/src/TabsCatalog.js
@@ -19,15 +19,17 @@ const TabsCatalog = () => {
   );
 };
 
-const TabsHero = () => {
-  return (
-    <TabBar>
-      <Tab active label='Home' />
-      <Tab label='Merchandise' />
-      <Tab label='About Us' />
-    </TabBar>
-  )
-};
+export class TabsHero extends Component {
+  render() {
+    return (
+        <TabBar>
+          <Tab active label='Home'/>
+          <Tab label='Merchandise'/>
+          <Tab label='About Us'/>
+        </TabBar>
+    )
+  }
+}
 
 const TabsDemos = () => {
   return (

--- a/src/TabsCatalog.js
+++ b/src/TabsCatalog.js
@@ -19,17 +19,15 @@ const TabsCatalog = () => {
   );
 };
 
-export class TabsHero extends Component {
-  render() {
-    return (
-        <TabBar>
-          <Tab active label='Home'/>
-          <Tab label='Merchandise'/>
-          <Tab label='About Us'/>
-        </TabBar>
-    )
-  }
-}
+export const TabsHero = () => {
+  return (
+      <TabBar>
+        <Tab active label='Home'/>
+        <Tab label='Merchandise'/>
+        <Tab label='About Us'/>
+      </TabBar>
+  )
+};
 
 const TabsDemos = () => {
   return (

--- a/src/TextFieldCatalog.js
+++ b/src/TextFieldCatalog.js
@@ -98,13 +98,11 @@ const TextFieldCatalog = () => (
   />
 );
 
-export class TextFieldHero extends Component {
-  render() {
-    return (
-        <TextField textFieldId='hero-text-field-id'/>
-    )
-  }
-}
+export const TextFieldHero = () => {
+  return (
+      <TextField textFieldId='hero-text-field-id'/>
+  )
+};
 
 class TextFieldDemos extends Component {
   renderFullWidthVariant(title, ...args) {

--- a/src/TextFieldCatalog.js
+++ b/src/TextFieldCatalog.js
@@ -88,7 +88,7 @@ const HelperText = () => (
 
 const TextFieldCatalog = () => (
   <ComponentCatalogPanel
-    hero={<TextField textFieldId='hero-text-field-id'/>}
+    hero={<TextFieldHero />}
     title='Text Field'
     description='Text fields allow users to input, edit, and select text. Text fields typically reside in forms but can appear in other places, like dialog boxes and search.'
     designLink='https://material.io/go/design-text-fields'
@@ -98,6 +98,13 @@ const TextFieldCatalog = () => (
   />
 );
 
+export class TextFieldHero extends Component {
+  render() {
+    return (
+        <TextField textFieldId='hero-text-field-id'/>
+    )
+  }
+}
 
 class TextFieldDemos extends Component {
   renderFullWidthVariant(title, ...args) {

--- a/src/TopAppBarCatalog.js
+++ b/src/TopAppBarCatalog.js
@@ -18,7 +18,7 @@ const TopAppBarCatalog = (props) => {
   );
 };
 
-class TopAppBarHero extends Component {
+export class TopAppBarHero extends Component {
 
   ripples = [];
 

--- a/src/TypographyCatalog.js
+++ b/src/TypographyCatalog.js
@@ -15,7 +15,7 @@ const TypographyCatalog = () => {
   )
 };
 
-export const TypographyHero = () => {
+const TypographyHero = () => {
   return (
     <div>
       <h1 className='mdc-typography--headline1'>Typography</h1>

--- a/src/TypographyCatalog.js
+++ b/src/TypographyCatalog.js
@@ -15,15 +15,13 @@ const TypographyCatalog = () => {
   )
 };
 
-export class TypographyHero extends Component {
-  render() {
-    return (
-        <div>
-          <h1 className='mdc-typography--headline1'>Typography</h1>
-        </div>
-    )
-  }
-}
+export const TypographyHero = () => {
+  return (
+    <div>
+      <h1 className='mdc-typography--headline1'>Typography</h1>
+    </div>
+  )
+};
 
 const TypographyDemos = () => {
   return (

--- a/src/TypographyCatalog.js
+++ b/src/TypographyCatalog.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 
 const TypographyCatalog = () => {

--- a/src/TypographyCatalog.js
+++ b/src/TypographyCatalog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import ComponentCatalogPanel from './ComponentCatalogPanel.js';
 
 const TypographyCatalog = () => {
@@ -15,13 +15,15 @@ const TypographyCatalog = () => {
   )
 };
 
-const TypographyHero = () => {
-  return (
-    <div>
-      <h1 className='mdc-typography--headline1'>Typography</h1>
-    </div>
-  )
-};
+export class TypographyHero extends Component {
+  render() {
+    return (
+        <div>
+          <h1 className='mdc-typography--headline1'>Typography</h1>
+        </div>
+    )
+  }
+}
 
 const TypographyDemos = () => {
   return (


### PR DESCRIPTION
This adds routes to just render the hero demo of each component page by itself so we can render the hero section inside of the spec articles as part of an experiment. 

This also creates a `Hero` component for all pages that didn't have one. It also converts the function components to class Hero components. 