### PR TITLE
Fix button flex direction when on smaller screens for m.io experiment

### DIFF
--- a/src/ButtonCatalog.js
+++ b/src/ButtonCatalog.js
@@ -34,7 +34,7 @@ export class ButtonHero extends Component {
 
   render() {
     return (
-      <div>
+      <div className='hero-button-container'>
         <button className='hero-button mdc-button' ref={this.initRipple} onClick={this.clickEvent}>
           <span className='mdc-button__label'>Text</span>
         </button>

--- a/src/styles/ButtonCatalog.scss
+++ b/src/styles/ButtonCatalog.scss
@@ -9,6 +9,16 @@
   margin: 16px 32px;
 }
 
+.hero-button-container {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+
+  @media screen and (max-width: 600px) {
+    flex-flow: column nowrap;
+  }
+}
+
 .demo-button-shaped {
   @include mdc-button-shape-radius(50%);
 }


### PR DESCRIPTION
Quick fix to cause the button in the hero section to change their flex direction on smaller screens to be  stacked in a column. 