### PR TITLE
Remove redundant list imports in multiple bundles

### DIFF
--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -3,6 +3,7 @@
 @import "@material/image-list/mixins";
 @import "@material/ripple/mdc-ripple";
 @import "@material/theme/color-palette";
+@import "@material/list/mdc-list";
 
 $breakpoints: (
   mobile:  320px,

--- a/src/styles/ComponentPage.scss
+++ b/src/styles/ComponentPage.scss
@@ -1,4 +1,3 @@
-@import "@material/list/mdc-list";
 @import "@material/drawer/mdc-drawer";
 @import "@material/typography/mixins";
 @import "./variables";

--- a/src/styles/ComponentView.scss
+++ b/src/styles/ComponentView.scss
@@ -1,5 +1,4 @@
 @import "@material/layout-grid/mdc-layout-grid";
-@import "@material/list/mdc-list";
 @import "@material/typography/mixins";
 
 .hero {

--- a/src/styles/HeroComponent.scss
+++ b/src/styles/HeroComponent.scss
@@ -111,7 +111,3 @@ $heroBackgroundColor: #f7f7f7;
 .react-syntax-highlighter-line-number {
   user-select: none;
 }
-
-.option-descr {
-  display: inline-block;
-}

--- a/src/styles/HeroComponent.scss
+++ b/src/styles/HeroComponent.scss
@@ -111,3 +111,7 @@ $heroBackgroundColor: #f7f7f7;
 .react-syntax-highlighter-line-number {
   user-select: none;
 }
+
+.option-descr {
+  display: inline-block;
+}

--- a/src/styles/ListCatalog.scss
+++ b/src/styles/ListCatalog.scss
@@ -1,4 +1,3 @@
-@import "@material/list/mdc-list";
 @import "@material/list/mixins";
 
 .hero-list {

--- a/src/styles/SelectCatalog.scss
+++ b/src/styles/SelectCatalog.scss
@@ -1,4 +1,3 @@
-@import "@material/list/mdc-list";
 @import "@material/menu-surface/mdc-menu-surface";
 @import "@material/menu/mdc-menu";
 @import "@material/select/mdc-select";


### PR DESCRIPTION
Adds the list import to the top level App.scss since there were 4 instances included globally (sass files are not route/component specific). 