### PR TITLE
Fix tab click event to use label text

### DIFF
--- a/src/hero/HeroComponent.js
+++ b/src/hero/HeroComponent.js
@@ -106,7 +106,7 @@ class Tab extends Component {
     ReactGA.event({
       category: gtagTabCategory,
       action: 'tab_clicked',
-      label: `tab_clicked_${tabNames[this.props.tabPosition]}`
+      label: `tab_clicked_${this.props.children}`
     });
   };
 


### PR DESCRIPTION
The tabs were refactored and this was missed. The google analytics events are coming in as `tab_clicked_undefined` since the tabPosition prop was removed. The children element passed in is the tab label text. 