### PR TITLE
Fix Analytics

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,10 @@
 const imagePath = `${window.location.origin}${window.location.pathname}static/media`;
 
-const gtagCategory = 'Component Interaction';
-const gtagTabCategory = 'Demo Tab Interaction';
-const gtagCopyCode = 'Copy Code Interaction';
 const gtagButtonAction = 'button_click';
+const gtagCategory = 'Component Interaction';
+const gtagCodeSnippetsCategory = 'CodeSnippets';
+const gtagCopyCode = 'Copy Code Interaction';
+const gtagTabCategory = 'Demo Tab Interaction';
 const gtagTextFieldAction = 'text_field_click';
 
-export {imagePath, gtagButtonAction, gtagCategory, gtagTabCategory, gtagCopyCode, gtagTextFieldAction};
+export {imagePath, gtagButtonAction, gtagCategory, gtagCodeSnippetsCategory, gtagCopyCode, gtagTabCategory, gtagTextFieldAction};

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,30 @@ import {HashRouter} from 'react-router-dom';
 import createHistory from 'history/createBrowserHistory';
 
 import ReactGA from 'react-ga';
+import {gtagCodeSnippetsCategory} from './constants';
 
 ReactGA.initialize('UA-118996389-1');
 
+// This ensures the first page view is captured
+let previousPath = window.location.hash.split('?')[0];
+ReactGA.set({page: previousPath});
+ReactGA.pageview(previousPath);
+
 const history = createHistory();
+
+// When the history changes, the current component path should be compared to the
+// previous path to ensure that adjusting the variant types doesn't register
+// as different page views.
 const historyListener = (location) => {
-  ReactGA.set({ page: location.hash });
-  ReactGA.pageview(location.hash);
+  const currPath = location.hash.split('?')[0];
+  if (previousPath !== currPath) {
+    ReactGA.set({page: location.hash});
+    ReactGA.pageview(location.hash);
+    previousPath = currPath;
+  } else {
+    // Variant change event so the code snippets usage gets tracked.
+    ReactGA.event({category: gtagCodeSnippetsCategory, action: previousPath, label: location.hash});
+  }
 };
 
 history.listen(historyListener);


### PR DESCRIPTION
Analytics is tracking each variant/label change for the code snippets as separate page views which is tanking our stats. This update tracks the previous path with the current path to ensure we don't register a page view when the user just changed the variant type. 